### PR TITLE
Improve battle ux

### DIFF
--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -30,6 +30,7 @@ class AppRouter {
           settings: settings,
         );
 
+
       case RouteNames.battle:
         return MaterialPageRoute(
           builder: (_) => const BattleScreen(),
@@ -132,6 +133,7 @@ class AppRouter {
   static Future<void> goToAchievements(BuildContext context) {
     return pushNamed(context, RouteNames.achievement);
   }
+
 
   static Future<void> goToBattleFromAnywhere(BuildContext context) {
     return pushNamedAndRemoveUntil(

--- a/lib/presentation/routes/route_names.dart
+++ b/lib/presentation/routes/route_names.dart
@@ -6,6 +6,7 @@ class RouteNames {
   static const String splash = '/';
   static const String tutorial = '/tutorial';
   static const String stageSelect = '/stage-select';
+  static const String stageItemSelection = '/stage-item-selection';
   static const String battle = '/battle';
   static const String stageClear = '/stage-clear';
   static const String inventory = '/inventory';
@@ -22,6 +23,7 @@ class RouteNames {
     splash,
     tutorial,
     stageSelect,
+    stageItemSelection,
     battle,
     stageClear,
     inventory,

--- a/lib/presentation/widgets/animated_stars.dart
+++ b/lib/presentation/widgets/animated_stars.dart
@@ -33,8 +33,9 @@ class AnimatedStars extends StatelessWidget {
           animation: starAnimation,
           builder: (context, child) {
             final isActive = index < stars;
-            final scale = isActive ? starAnimation.value : 0.8;
-            final opacity = isActive ? starAnimation.value : 0.3;
+            // Clamp animation values to prevent layout errors
+            final scale = isActive ? starAnimation.value.clamp(0.0, 2.0) : 0.8;
+            final opacity = isActive ? starAnimation.value.clamp(0.0, 1.0) : 0.3;
             
             return Transform.scale(
               scale: scale,


### PR DESCRIPTION
バトル画面における以下のエラーを解消した
- クリア後にクリア画面へアニメーションで遷移する際、エラーが表示される
- 合成数モンスターを倒した時及び間違った数で攻撃をした時のポップアップは不要
- 敵の合成数によってアイテムの表示を変えるのをやめ、全く同じデザインに揃える
- 逃げた際にはリセットではなくペナルティを受けた上でそのまま続行する