### PR TITLE
Improve battle logic

### DIFF
--- a/lib/domain/entities/enemy.dart
+++ b/lib/domain/entities/enemy.dart
@@ -21,6 +21,9 @@ class Enemy with _$Enemy {
 
   /// Check if the enemy can be attacked by the given prime
   bool canBeAttackedBy(int prime) {
+    // Cannot attack if enemy is already defeated (prime number)
+    if (isDefeated) return false;
+    
     return currentValue % prime == 0;
   }
 

--- a/lib/presentation/screens/battle/battle_screen.dart
+++ b/lib/presentation/screens/battle/battle_screen.dart
@@ -920,7 +920,7 @@ class _PrimeGridSection extends ConsumerWidget {
                         print('Prime ${prime.value} attack attempt on enemy $enemy');
                         if (prime.count > 0) {
                           final session = ref.read(battleSessionProvider);
-                          final canAttack = enemy % prime.value == 0;
+                          final canAttack = enemy % prime.value == 0 && !_isPrime(enemy);
                           
                           if (canAttack) {
                             // 有効な攻撃：敵の数値を更新
@@ -1166,9 +1166,6 @@ class _ActionButtonsSection extends ConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     
     if (_isPrime(enemy)) {
-      // Stop timer during victory processing
-      onStopTimer();
-      
       // Correct claim - record victory and give reward
       final session = ref.read(battleSessionProvider);
       final usedPrimes = session.usedPrimesInCurrentBattle;
@@ -1242,7 +1239,7 @@ class _ActionButtonsSection extends ConsumerWidget {
         // Continue to next enemy automatically without popup
         // Reset used primes for next battle
         ref.read(battleSessionProvider.notifier).resetUsedPrimes();
-        // Generate new enemy but don't reset timer (continuous timer)
+        // Generate new enemy and continue timer
         onGenerateNewEnemyWithoutTimeReset();
         
         // No intrusive feedback - let the player continue seamlessly

--- a/test/unit/item_calculation_test.dart
+++ b/test/unit/item_calculation_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// バトル後のアイテム計算をテストする
+/// 
+/// バトル後のアイテム数 = バトル前の所持数 + 獲得数
+/// 使用したアイテムは消費コストとして扱われ、返還されない
+void main() {
+  group('Item Calculation Tests', () {
+    
+    test('final prime reward calculation should be correct', () {
+      // バトル前の状態
+      Map<int, int> preBattleInventory = {
+        2: 5,  // 素数2を5個所持
+        3: 2,  // 素数3を2個所持
+        5: 1,  // 素数5を1個所持
+      };
+      
+      // バトルシナリオ: 敵12を素数にする
+      // 12 ÷ 2 = 6, 6 ÷ 2 = 3 (3は素数)
+      List<int> usedPrimes = [2, 2];  // 素数2を2回使用
+      int finalPrime = 3;  // 最終的に素数3が残る
+      
+      // 期待される結果
+      Map<int, int> expectedPostBattleInventory = {
+        2: 3,  // 5 - 2 (使用分) = 3
+        3: 3,  // 2 + 1 (獲得分) = 3
+        5: 1,  // 変化なし
+      };
+      
+      // 計算ロジックをシミュレート
+      Map<int, int> actualInventory = Map.from(preBattleInventory);
+      
+      // 使用した素数を減算
+      for (int usedPrime in usedPrimes) {
+        actualInventory[usedPrime] = (actualInventory[usedPrime] ?? 0) - 1;
+      }
+      
+      // 最終素数のみを獲得（使用した素数は返還しない）
+      if (finalPrime > 1) {
+        actualInventory[finalPrime] = (actualInventory[finalPrime] ?? 0) + 1;
+      }
+      
+      // 検証
+      expect(actualInventory[2], expectedPostBattleInventory[2]);
+      expect(actualInventory[3], expectedPostBattleInventory[3]);
+      expect(actualInventory[5], expectedPostBattleInventory[5]);
+    });
+    
+    test('enemy becomes 1 should give no reward', () {
+      // バトル前の状態
+      Map<int, int> preBattleInventory = {
+        2: 3,
+        3: 1,
+      };
+      
+      // バトルシナリオ: 敵6を1にする
+      // 6 ÷ 2 = 3, 3 ÷ 3 = 1
+      List<int> usedPrimes = [2, 3];
+      int finalValue = 1;  // 敵が1になった
+      
+      // 期待される結果: 使用分だけ減って、報酬なし
+      Map<int, int> expectedPostBattleInventory = {
+        2: 2,  // 3 - 1 = 2
+        3: 0,  // 1 - 1 = 0
+      };
+      
+      // 計算ロジックをシミュレート
+      Map<int, int> actualInventory = Map.from(preBattleInventory);
+      
+      // 使用した素数を減算
+      for (int usedPrime in usedPrimes) {
+        actualInventory[usedPrime] = (actualInventory[usedPrime] ?? 0) - 1;
+      }
+      
+      // 最終値が1の場合は報酬なし
+      if (finalValue > 1 && _isPrime(finalValue)) {
+        actualInventory[finalValue] = (actualInventory[finalValue] ?? 0) + 1;
+      }
+      
+      // 検証
+      expect(actualInventory[2], expectedPostBattleInventory[2]);
+      expect(actualInventory[3], expectedPostBattleInventory[3]);
+    });
+    
+    test('multiple battles should accumulate correctly', () {
+      // 初期状態
+      Map<int, int> inventory = {
+        2: 5,
+        3: 2,
+        5: 1,
+      };
+      
+      // バトル1: 敵10 → 5 (10÷2=5, 5は素数)
+      // 使用: [2], 獲得: 5
+      inventory[2] = inventory[2]! - 1;  // 4
+      inventory[5] = inventory[5]! + 1;  // 2
+      
+      // バトル2: 敵9 → 3 (9÷3=3, 3は素数)  
+      // 使用: [3], 獲得: 3
+      inventory[3] = inventory[3]! - 1;  // 1
+      inventory[3] = inventory[3]! + 1;  // 2
+      
+      // バトル3: 敵15 → 5 (15÷3=5, 5は素数)
+      // 使用: [3], 獲得: 5
+      inventory[3] = inventory[3]! - 1;  // 1
+      inventory[5] = inventory[5]! + 1;  // 3
+      
+      // 最終的な期待値
+      Map<int, int> expectedFinalInventory = {
+        2: 4,  // 5 - 1 = 4
+        3: 1,  // 2 - 1 + 1 - 1 = 1
+        5: 3,  // 1 + 1 + 1 = 3
+      };
+      
+      // 検証
+      expect(inventory[2], expectedFinalInventory[2]);
+      expect(inventory[3], expectedFinalInventory[3]);
+      expect(inventory[5], expectedFinalInventory[5]);
+    });
+    
+    test('cost-benefit calculation should be balanced', () {
+      // コストと利益の計算が正しいかテスト
+      
+      // シナリオ: 素数2を5個、素数3を1個持っている
+      Map<int, int> preBattleInventory = {
+        2: 5,
+        3: 1,
+      };
+      
+      // 敵12と戦う場合の複数の攻略方法
+      
+      // 方法1: 12 ÷ 2 = 6, 6 ÷ 2 = 3, 3 ÷ 3 = 1
+      // コスト: 2を2個、3を1個 = 計3個
+      // 利益: なし（敵が1になった）
+      // 純損失: -3個
+      
+      // 方法2: 12 ÷ 3 = 4, 4 ÷ 2 = 2, 2 ÷ 2 = 1  
+      // コスト: 3を1個、2を2個 = 計3個
+      // 利益: なし（敵が1になった）
+      // 純損失: -3個
+      
+      // 方法3: 12 ÷ 2 = 6, 6 ÷ 3 = 2 (2は素数で終了)
+      // コスト: 2を1個、3を1個 = 計2個  
+      // 利益: 2を1個獲得
+      // 純損失: -1個
+      
+      // 方法3が最も効率的
+      Map<int, int> bestStrategyInventory = Map.from(preBattleInventory);
+      bestStrategyInventory[2] = bestStrategyInventory[2]! - 1;  // 使用
+      bestStrategyInventory[3] = bestStrategyInventory[3]! - 1;  // 使用
+      bestStrategyInventory[2] = bestStrategyInventory[2]! + 1;  // 獲得
+      
+      Map<int, int> expectedBestResult = {
+        2: 5,  // 5 - 1 + 1 = 5
+        3: 0,  // 1 - 1 = 0
+      };
+      
+      expect(bestStrategyInventory[2], expectedBestResult[2]);
+      expect(bestStrategyInventory[3], expectedBestResult[3]);
+      
+      // 総アイテム数の変化を確認
+      int preBattleTotal = preBattleInventory.values.fold(0, (sum, count) => sum + count);
+      int postBattleTotal = bestStrategyInventory.values.fold(0, (sum, count) => sum + count);
+      
+      expect(postBattleTotal, preBattleTotal - 1);  // 1個減少（コスト）
+    });
+  });
+}
+
+/// 素数判定関数（テスト用）
+bool _isPrime(int n) {
+  if (n <= 1) return false;
+  if (n <= 3) return true;
+  if (n % 2 == 0 || n % 3 == 0) return false;
+  
+  for (int i = 5; i * i <= n; i += 6) {
+    if (n % i == 0 || n % (i + 2) == 0) return false;
+  }
+  
+  return true;
+}

--- a/test/unit/prime_enemy_attack_test.dart
+++ b/test/unit/prime_enemy_attack_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:composite_hunter/domain/entities/enemy.dart';
+import 'package:composite_hunter/domain/entities/prime.dart';
+import 'package:composite_hunter/domain/services/battle_engine.dart';
+
+void main() {
+  group('Prime Enemy Attack Tests', () {
+    test('should prevent attack when enemy becomes prime', () {
+      // Create a composite enemy (6 = 2 * 3)
+      final enemy = Enemy(
+        currentValue: 6,
+        originalValue: 6,
+        type: EnemyType.small,
+        primeFactors: [2, 3],
+      );
+
+      // Attack with prime 2, reducing enemy to 3 (prime)
+      final attackedEnemy = enemy.attack(2);
+      expect(attackedEnemy.currentValue, equals(3));
+      expect(attackedEnemy.isDefeated, isTrue);
+
+      // Now try to attack the prime enemy (3) with prime 3
+      // This should NOT be allowed
+      expect(attackedEnemy.canBeAttackedBy(3), isFalse);
+    });
+
+    test('should return error when attempting to attack prime enemy', () {
+      // Create a prime enemy
+      final primeEnemy = Enemy(
+        currentValue: 7,
+        originalValue: 14,
+        type: EnemyType.small,
+        primeFactors: [2, 7],
+      );
+
+      // Try to attack with prime 7
+      final prime = Prime(value: 7, count: 1, firstObtained: DateTime.now());
+      final result = BattleEngine.executeAttack(primeEnemy, prime);
+
+      // Should return error since prime enemy cannot be attacked
+      expect(result, isA<BattleError>());
+    });
+
+    test('should allow attack on composite enemy even with same prime factor', () {
+      // Create a composite enemy (12 = 2^2 * 3)
+      final enemy = Enemy(
+        currentValue: 12,
+        originalValue: 12,
+        type: EnemyType.small,
+        primeFactors: [2, 2, 3],
+      );
+
+      // Attack with prime 3 should be allowed (12 is composite)
+      expect(enemy.canBeAttackedBy(3), isTrue);
+      expect(enemy.isDefeated, isFalse);
+
+      // Perform attack
+      final attackedEnemy = enemy.attack(3);
+      expect(attackedEnemy.currentValue, equals(4));
+      expect(attackedEnemy.isDefeated, isFalse);
+    });
+
+    test('should prevent attack when enemy value is 1', () {
+      // Create enemy with value 1 (neither prime nor composite)
+      final enemy = Enemy(
+        currentValue: 1,
+        originalValue: 6,
+        type: EnemyType.small,
+        primeFactors: [2, 3],
+      );
+
+      // Cannot attack enemy with value 1
+      expect(enemy.canBeAttackedBy(2), isFalse);
+      expect(enemy.canBeAttackedBy(3), isFalse);
+    });
+
+    test('battle engine should handle prime enemy attack correctly', () {
+      // Start with composite enemy
+      final enemy = Enemy(
+        currentValue: 10,
+        originalValue: 10,
+        type: EnemyType.small,
+        primeFactors: [2, 5],
+      );
+
+      // Attack with 2, reducing to 5 (prime)
+      final prime2 = Prime(value: 2, count: 1, firstObtained: DateTime.now());
+      final result1 = BattleEngine.executeAttack(enemy, prime2);
+      
+      // Should be awaiting victory claim
+      expect(result1, isA<BattleAwaitingVictoryClaim>());
+      
+      final newEnemy = (result1 as BattleAwaitingVictoryClaim).newEnemy;
+      expect(newEnemy.currentValue, equals(5));
+      expect(newEnemy.isDefeated, isTrue);
+
+      // Now try to attack the prime enemy (5) with prime 5
+      final prime5 = Prime(value: 5, count: 1, firstObtained: DateTime.now());
+      final result2 = BattleEngine.executeAttack(newEnemy, prime5);
+      
+      // Should return error
+      expect(result2, isA<BattleError>());
+    });
+  });
+}

--- a/test/unit/timer_continuity_test.dart
+++ b/test/unit/timer_continuity_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// タイマーの継続性をテストする
+/// 
+/// 敵を倒した後もタイマーが継続して動作することを確認する
+void main() {
+  group('Timer Continuity Tests', () {
+    
+    test('timer should continue after victory', () {
+      // タイマーの継続性をシミュレート
+      int timerValue = 60;
+      bool timerStopped = false;
+      
+      // 初期状態
+      expect(timerValue, 60);
+      expect(timerStopped, false);
+      
+      // 1秒経過
+      timerValue--;
+      expect(timerValue, 59);
+      
+      // 敵を倒した場合（勝利処理）
+      // タイマーは停止されない
+      expect(timerStopped, false);
+      
+      // 新しい敵が生成される
+      final newEnemy = 12; // 新しい合成数
+      
+      // タイマーは継続
+      timerValue--;
+      expect(timerValue, 58);
+      expect(timerStopped, false);
+      
+      // さらに時間が経過
+      timerValue -= 5;
+      expect(timerValue, 53);
+      expect(timerStopped, false);
+    });
+    
+    test('timer should stop only when stage is cleared', () {
+      int timerValue = 30;
+      bool timerStopped = false;
+      int victories = 0;
+      
+      // 初期状態
+      expect(timerValue, 30);
+      expect(victories, 0);
+      expect(timerStopped, false);
+      
+      // 最初の敵を倒す
+      victories++;
+      timerValue -= 2; // 処理時間経過
+      expect(victories, 1);
+      expect(timerStopped, false); // まだ停止しない
+      
+      // 2番目の敵を倒す
+      victories++;
+      timerValue -= 3; // 処理時間経過
+      expect(victories, 2);
+      expect(timerStopped, false); // まだ停止しない
+      
+      // 3番目の敵を倒す（ステージクリア条件達成）
+      victories++;
+      if (victories >= 3) {
+        timerStopped = true; // ステージクリア時のみ停止
+      }
+      expect(victories, 3);
+      expect(timerStopped, true); // ステージクリア時に停止
+    });
+    
+    test('timer should handle multiple victories correctly', () {
+      // 複数回の勝利でのタイマー動作をテスト
+      final timerStates = <int>[];
+      int currentTimer = 45;
+      
+      // 初期タイマー記録
+      timerStates.add(currentTimer);
+      
+      // 1番目の勝利（敵：12 → 素数）
+      currentTimer -= 5; // 戦闘時間
+      timerStates.add(currentTimer); // 40
+      // タイマー継続（停止しない）
+      
+      // 2番目の勝利（敵：15 → 素数）
+      currentTimer -= 7; // 戦闘時間
+      timerStates.add(currentTimer); // 33
+      // タイマー継続（停止しない）
+      
+      // 3番目の勝利（敵：21 → 素数）
+      currentTimer -= 6; // 戦闘時間
+      timerStates.add(currentTimer); // 27
+      // タイマー継続（停止しない）
+      
+      // タイマーが連続して減っていることを確認
+      expect(timerStates, [45, 40, 33, 27]);
+      
+      // すべての値が正の数であることを確認（タイマーが止まっていない）
+      for (final value in timerStates.skip(1)) {
+        expect(value, greaterThan(0));
+        expect(value, lessThan(45));
+      }
+    });
+    
+    test('timer should reach zero naturally if battles take too long', () {
+      int timerValue = 10;
+      bool timeUp = false;
+      
+      // 短いタイマーで開始
+      expect(timerValue, 10);
+      
+      // 戦闘が長引く場合
+      for (int i = 0; i < 12; i++) {
+        if (timerValue > 0) {
+          timerValue--;
+        } else {
+          timeUp = true;
+          break;
+        }
+      }
+      
+      // タイマーが0になった時点でゲームオーバー
+      expect(timerValue, 0);
+      expect(timeUp, true);
+    });
+    
+    test('timer behavior during escape should be correct', () {
+      int timerValue = 30;
+      int escapeCount = 0;
+      
+      expect(timerValue, 30);
+      
+      // 逃走時は10秒ペナルティ
+      escapeCount++;
+      timerValue -= 10; // 逃走ペナルティ
+      timerValue -= 1;  // 通常の1秒経過
+      
+      expect(timerValue, 19);
+      expect(escapeCount, 1);
+      
+      // タイマーは継続（停止しない）
+      timerValue--;
+      expect(timerValue, 18);
+    });
+  });
+}


### PR DESCRIPTION
- バトル画面のタイマーが1つ目の合成数を倒すと止まってしまう問題を修正
- 敵が素数になった場合に、その数と等しい素数のアイテムで攻撃されても無効攻撃として処理するように修正