### PR TITLE
Fix item logic

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(git config:*)",
       "Bash(git commit:*)",
       "Bash(git reset:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(./gradlew:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "Bash(git commit:*)",
       "Bash(git reset:*)",
       "Bash(git add:*)",
-      "Bash(./gradlew:*)"
+      "Bash(./gradlew:*)",
+      "Bash(timeout 30 flutter test:*)"
     ],
     "deny": []
   }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.composite_hunter"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -45,8 +45,8 @@ android {
         applicationId "com.example.composite_hunter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion 21
+        targetSdk 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/docs/database_design.md
+++ b/docs/database_design.md
@@ -1,10 +1,11 @@
-## 合成数ハンター データベース設計書（統合最新版）
+## 合成数ハンター データベース設計書（修正版v4）
 
 ### 1. データベース概要
 
 - **データベース種別**: SQLite（ローカル DB）
-- **目的**: ユーザーの進捗、インベントリ、戦闘履歴、タイマー状態、勝利判定、実績などの永続化
+- **目的**: ユーザーの進捗、インベントリ、ステージ進行、戦闘履歴、仮報酬、タイマー状態、勝利判定、実績などの永続化
 - **対象層**: データレイヤー（`data/datasources/local_database.dart`）
+- **新機能**: ステージシステム、アイテム消費システム、仮報酬管理に対応
 
 ---
 
@@ -16,61 +17,136 @@
 | ---------------------------- | ------- | -------- | ------ | -------------------- |
 | id                           | INTEGER | YES      | YES    | 自動採番 ID          |
 | player_level                 | INTEGER | YES      |        | プレイヤーレベル     |
+| current_stage                | INTEGER | YES      |        | 現在のステージ       |
+| max_unlocked_stage           | INTEGER | YES      |        | 最大解放ステージ     |
 | total_experience             | INTEGER | YES      |        | 累計経験値           |
 | total_battles                | INTEGER | YES      |        | 総バトル数           |
 | total_victories              | INTEGER | YES      |        | 勝利数               |
-| total_primes_collected       | INTEGER | YES      |        | 素数獲得総数         |
+| total_stage_clears           | INTEGER | YES      |        | ステージクリア数     |
+| total_stage_failures         | INTEGER | YES      |        | ステージ失敗数       |
+| total_items_collected        | INTEGER | YES      |        | アイテム獲得総数     |
+| total_items_consumed         | INTEGER | YES      |        | アイテム消費総数     |
 | total_power_enemies_defeated | INTEGER | YES      |        | 累乗敵の撃破数       |
 | total_time_penalties         | INTEGER | YES      |        | 時間ペナルティの合計 |
 | win_rate                     | REAL    | YES      |        | 勝率（0〜1）         |
+| stage_clear_rate             | REAL    | YES      |        | ステージクリア率     |
 | victory_claim_accuracy       | REAL    | YES      |        | 勝利判定精度         |
 | created_at                   | TEXT    | YES      |        | 作成日時（ISO8601）  |
 | updated_at                   | TEXT    | YES      |        | 更新日時（ISO8601）  |
 
-#### 2.2 `prime_inventory` テーブル
+#### 2.2 `stages` テーブル（新規）
 
-| カラム名            | 型      | NOT NULL | 主キー | 備考                   |
-| ------------------- | ------- | -------- | ------ | ---------------------- |
-| id                  | INTEGER | YES      | YES    | 自動採番 ID            |
-| prime_value         | INTEGER | YES      | UNIQUE | 素数値                 |
-| count               | INTEGER | YES      |        | 所持数                 |
-| total_obtained      | INTEGER | YES      |        | 累計取得数             |
-| usage_count         | INTEGER | YES      |        | 使用回数               |
-| power_enemy_rewards | INTEGER | YES      |        | 累乗敵からの報酬数     |
-| first_obtained_at   | TEXT    | YES      |        | 初取得日時（ISO 8601） |
-| last_used_at        | TEXT    | NO       |        | 最終使用日時           |
-| created_at          | TEXT    | YES      |        | 作成日時               |
-| updated_at          | TEXT    | YES      |        | 更新日時               |
+| カラム名               | 型      | NOT NULL | 主キー | 備考                      |
+| ---------------------- | ------- | -------- | ------ | ------------------------- |
+| id                     | INTEGER | YES      | YES    | 自動採番 ID               |
+| stage_number           | INTEGER | YES      | UNIQUE | ステージ番号              |
+| stage_name             | TEXT    | YES      |        | ステージ名                |
+| stage_description      | TEXT    | YES      |        | ステージ説明              |
+| stage_type             | TEXT    | YES      |        | tutorial/normal/challenge |
+| difficulty_level       | TEXT    | YES      |        | easy/normal/hard/extreme  |
+| slot_limit             | INTEGER | YES      |        | 持込アイテム上限数        |
+| base_time_seconds      | INTEGER | YES      |        | 基本制限時間（秒）        |
+| enemy_count            | INTEGER | YES      |        | 敵の数                    |
+| min_enemy_value        | INTEGER | YES      |        | 敵の最小値                |
+| max_enemy_value        | INTEGER | YES      |        | 敵の最大値                |
+| is_unlocked            | INTEGER | YES      |        | 1:解放済, 0:未解放        |
+| unlock_condition       | TEXT    | NO       |        | 解放条件（JSON）          |
+| rewards                | TEXT    | YES      |        | 報酬情報（JSON）          |
+| best_clear_time_ms     | INTEGER | NO       |        | 最速クリア時間（ms）      |
+| total_attempts         | INTEGER | YES      |        | 挑戦回数                  |
+| total_clears           | INTEGER | YES      |        | クリア回数                |
+| first_unlocked_at      | TEXT    | NO       |        | 初回解放日時              |
+| first_cleared_at       | TEXT    | NO       |        | 初回クリア日時            |
+| last_attempted_at      | TEXT    | NO       |        | 最終挑戦日時              |
+| created_at             | TEXT    | YES      |        | 作成日時                  |
+| updated_at             | TEXT    | YES      |        | 更新日時                  |
 
-#### 2.3 `battle_history` テーブル
+#### 2.3 `item_inventory` テーブル（prime_inventoryから改名・更新）
+
+| カラム名             | 型      | NOT NULL | 主キー | 備考                   |
+| -------------------- | ------- | -------- | ------ | ---------------------- |
+| id                   | INTEGER | YES      | YES    | 自動採番 ID            |
+| item_value           | INTEGER | YES      | UNIQUE | アイテム値（素数値）   |
+| item_type            | TEXT    | YES      |        | prime/special など     |
+| count                | INTEGER | YES      |        | 所持数                 |
+| total_obtained       | INTEGER | YES      |        | 累計取得数             |
+| total_consumed       | INTEGER | YES      |        | 累計消費数             |
+| battle_usage_count   | INTEGER | YES      |        | 戦闘使用回数           |
+| power_enemy_rewards  | INTEGER | YES      |        | 累乗敵からの報酬数     |
+| stage_rewards        | INTEGER | YES      |        | ステージ報酬からの獲得 |
+| temp_rewards         | INTEGER | YES      |        | 仮報酬からの獲得       |
+| first_obtained_at    | TEXT    | YES      |        | 初取得日時（ISO 8601） |
+| last_used_at         | TEXT    | NO       |        | 最終使用日時           |
+| last_obtained_at     | TEXT    | YES      |        | 最終取得日時           |
+| created_at           | TEXT    | YES      |        | 作成日時               |
+| updated_at           | TEXT    | YES      |        | 更新日時               |
+
+#### 2.4 `battle_sessions` テーブル（battle_historyから改名・更新）
 
 | カラム名                | 型      | NOT NULL | 主キー | 備考                          |
 | ----------------------- | ------- | -------- | ------ | ----------------------------- |
 | id                      | INTEGER | YES      | YES    | 自動採番 ID                   |
+| stage_id                | INTEGER | YES      |        | stages.id 外部キー            |
 | enemy_original_value    | INTEGER | YES      |        | 敵の元の値                    |
-| enemy_final_value       | INTEGER | YES      |        | 敵の残り HP 的な数値          |
+| enemy_final_value       | INTEGER | YES      |        | 敵の最終値                    |
 | enemy_type              | TEXT    | YES      |        | small/medium/large/power など |
 | is_power_enemy          | INTEGER | YES      |        | 1:累乗敵, 0:通常              |
 | power_base              | INTEGER | NO       |        | 累乗の底                      |
 | power_exponent          | INTEGER | NO       |        | 累乗の指数                    |
+| loadout_items           | TEXT    | YES      |        | 持込アイテム（JSON）          |
+| items_consumed          | TEXT    | YES      |        | 消費したアイテム（JSON）      |
 | turn_count              | INTEGER | YES      |        | ターン数                      |
+| attack_count            | INTEGER | YES      |        | 攻撃回数                      |
+| successful_attacks      | INTEGER | YES      |        | 成功した攻撃数                |
+| failed_attacks          | INTEGER | YES      |        | 失敗した攻撃数                |
+| prime_attacks           | INTEGER | YES      |        | 素数への攻撃数                |
 | battle_duration_ms      | INTEGER | YES      |        | バトル所要時間(ms)            |
 | timer_remaining_seconds | INTEGER | NO       |        | タイマー残り時間              |
-| battle_result           | TEXT    | YES      |        | victory/escape/timeout など   |
-| primes_used             | TEXT    | YES      |        | JSON 形式で記録               |
-| reward_prime            | INTEGER | NO       |        | 報酬素数                      |
-| reward_count            | INTEGER | YES      |        | 報酬個数（1 以上）            |
+| session_result          | TEXT    | YES      |        | stageComplete/stageFailed など|
+| temp_rewards_json       | TEXT    | YES      |        | 仮報酬情報（JSON）            |
+| finalized_rewards_json  | TEXT    | NO       |        | 確定報酬情報（JSON）          |
 | victory_claim_correct   | INTEGER | NO       |        | 1:正解, 0:誤り                |
 | victory_claim_attempts  | INTEGER | YES      |        | 勝利判定試行回数              |
-| battle_date             | TEXT    | YES      |        | バトル実行日（ISO 8601）      |
+| session_date            | TEXT    | YES      |        | セッション実行日（ISO 8601）  |
 | created_at              | TEXT    | YES      |        | 作成日時                      |
 
-#### 2.4 `timer_history` テーブル
+#### 2.5 `temp_rewards` テーブル（新規）
+
+| カラム名            | 型      | NOT NULL | 主キー | 備考                           |
+| ------------------- | ------- | -------- | ------ | ------------------------------ |
+| id                  | INTEGER | YES      | YES    | 自動採番 ID                    |
+| session_id          | INTEGER | YES      |        | battle_sessions.id 外部キー    |
+| item_value          | INTEGER | YES      |        | 仮獲得アイテム値               |
+| item_count          | INTEGER | YES      |        | 仮獲得数                       |
+| reward_source       | TEXT    | YES      |        | enemy/powerEnemy/stage など    |
+| source_enemy_value  | INTEGER | NO       |        | 報酬元の敵値                   |
+| is_finalized        | INTEGER | YES      |        | 1:確定済, 0:仮状態             |
+| obtained_at         | TEXT    | YES      |        | 仮獲得日時                     |
+| finalized_at        | TEXT    | NO       |        | 確定日時                       |
+| discarded_at        | TEXT    | NO       |        | 破棄日時                       |
+| created_at          | TEXT    | YES      |        | 作成日時                       |
+
+#### 2.6 `item_consumption_log` テーブル（新規）
+
+| カラム名           | 型      | NOT NULL | 主キー | 備考                        |
+| ------------------ | ------- | -------- | ------ | --------------------------- |
+| id                 | INTEGER | YES      | YES    | 自動採番 ID                 |
+| session_id         | INTEGER | YES      |        | battle_sessions.id 外部キー |
+| item_value         | INTEGER | YES      |        | 消費したアイテム値          |
+| consumption_reason | TEXT    | YES      |        | attack/failed_attack など   |
+| target_enemy_value | INTEGER | YES      |        | 攻撃対象の敵値              |
+| attack_successful  | INTEGER | YES      |        | 1:成功, 0:失敗              |
+| turn_number        | INTEGER | YES      |        | ターン番号                  |
+| consumed_at        | TEXT    | YES      |        | 消費日時                    |
+| created_at         | TEXT    | YES      |        | 作成日時                    |
+
+#### 2.7 `timer_history` テーブル（更新）
 
 | カラム名            | 型      | NOT NULL | 主キー | 備考                         |
 | ------------------- | ------- | -------- | ------ | ---------------------------- |
 | id                  | INTEGER | YES      | YES    | 自動採番 ID                  |
-| battle_id           | INTEGER | YES      |        | `battle_history.id` 外部キー |
+| session_id          | INTEGER | YES      |        | `battle_sessions.id` 外部キー|
+| stage_id            | INTEGER | YES      |        | stages.id 外部キー           |
 | original_seconds    | INTEGER | YES      |        | 元々の制限時間（秒）         |
 | final_seconds       | INTEGER | YES      |        | 最終残り時間（秒）           |
 | penalty_seconds     | INTEGER | YES      |        | ペナルティ秒数               |
@@ -80,31 +156,35 @@
 | timer_end_at        | TEXT    | NO       |        | 終了時刻                     |
 | created_at          | TEXT    | YES      |        | 作成日時                     |
 
-#### 2.5 `penalty_records` テーブル
+#### 2.8 `penalty_records` テーブル（更新）
 
-| カラム名        | 型      | NOT NULL | 主キー | 備考                                |
-| --------------- | ------- | -------- | ------ | ----------------------------------- |
-| id              | INTEGER | YES      | YES    | 自動採番 ID                         |
-| battle_id       | INTEGER | NO       |        | `battle_history.id` 外部キー        |
-| penalty_type    | TEXT    | YES      |        | escape/wrongVictoryClaim/timeout 等 |
-| penalty_seconds | INTEGER | YES      |        | ペナルティ時間（秒）                |
-| penalty_reason  | TEXT    | YES      |        | 理由                                |
-| applied_at      | TEXT    | YES      |        | 適用日時（ISO 8601）                |
-| created_at      | TEXT    | YES      |        | 作成日時                            |
+| カラム名        | 型      | NOT NULL | 主キー | 備考                                        |
+| --------------- | ------- | -------- | ------ | ------------------------------------------- |
+| id              | INTEGER | YES      | YES    | 自動採番 ID                                 |
+| session_id      | INTEGER | NO       |        | `battle_sessions.id` 外部キー               |
+| stage_id        | INTEGER | YES      |        | stages.id 外部キー                          |
+| penalty_type    | TEXT    | YES      |        | retire/wrongVictoryClaim/timeout/itemUsage |
+| penalty_seconds | INTEGER | YES      |        | ペナルティ時間（秒）                        |
+| penalty_reason  | TEXT    | YES      |        | 理由                                        |
+| applied_at      | TEXT    | YES      |        | 適用日時（ISO 8601）                        |
+| created_at      | TEXT    | YES      |        | 作成日時                                    |
 
-#### 2.6 `victory_claims` テーブル
+#### 2.9 `victory_claims` テーブル（更新）
 
 | カラム名        | 型      | NOT NULL | 主キー | 備考                         |
 | --------------- | ------- | -------- | ------ | ---------------------------- |
 | id              | INTEGER | YES      | YES    | 自動採番 ID                  |
-| battle_id       | INTEGER | YES      |        | `battle_history.id` 外部キー |
-| claimed_value   | INTEGER | YES      |        | ユーザーが主張した素数値     |
+| session_id      | INTEGER | YES      |        | `battle_sessions.id` 外部キー|
+| stage_id        | INTEGER | YES      |        | stages.id 外部キー           |
+| claimed_value   | INTEGER | YES      |        | ユーザーが主張した値         |
+| actual_value    | INTEGER | YES      |        | 実際の敵の値                 |
 | is_correct      | INTEGER | YES      |        | 1:正解, 0:誤り               |
 | penalty_applied | INTEGER | YES      |        | ペナルティ時間（秒）         |
+| reward_obtained | INTEGER | NO       |        | 獲得した報酬アイテム値       |
 | claimed_at      | TEXT    | YES      |        | 主張日時                     |
 | created_at      | TEXT    | YES      |        | 作成日時                     |
 
-#### 2.7 `power_enemy_encounters` テーブル
+#### 2.10 `power_enemy_encounters` テーブル（更新）
 
 | カラム名                  | 型      | NOT NULL | 主キー | 備考                     |
 | ------------------------- | ------- | -------- | ------ | ------------------------ |
@@ -112,115 +192,233 @@
 | enemy_value               | INTEGER | YES      | UNIQUE | 累乗敵の値               |
 | power_base                | INTEGER | YES      |        | 底                       |
 | power_exponent            | INTEGER | YES      |        | 指数                     |
+| stage_first_encountered   | INTEGER | YES      |        | 初遭遇ステージ           |
 | player_level_at_encounter | INTEGER | YES      |        | 遭遇時のプレイヤーレベル |
-| was_defeated              | INTEGER | YES      |        | 1:撃破済, 0:未撃破       |
+| total_encounters          | INTEGER | YES      |        | 遭遇回数                 |
+| total_defeats             | INTEGER | YES      |        | 撃破回数                 |
 | attempts_count            | INTEGER | YES      |        | 試行回数                 |
 | rewards_obtained          | INTEGER | YES      |        | 報酬数                   |
+| temp_rewards_lost         | INTEGER | YES      |        | 失った仮報酬数           |
 | first_encounter_at        | TEXT    | YES      |        | 初遭遇日時               |
 | last_encounter_at         | TEXT    | YES      |        | 最終遭遇日時             |
+| first_defeat_at           | TEXT    | NO       |        | 初撃破日時               |
 | created_at                | TEXT    | YES      |        | 作成日時                 |
 | updated_at                | TEXT    | YES      |        | 更新日時                 |
 
-#### 2.8 `achievements` テーブル
+#### 2.11 `achievements` テーブル（更新）
 
-| カラム名                | 型      | NOT NULL | 主キー | 備考                    |
-| ----------------------- | ------- | -------- | ------ | ----------------------- |
-| id                      | INTEGER | YES      | YES    | 自動採番 ID             |
-| achievement_id          | TEXT    | YES      | UNIQUE | 識別子                  |
-| achievement_name        | TEXT    | YES      |        | 名前                    |
-| achievement_description | TEXT    | YES      |        | 説明                    |
-| achievement_category    | TEXT    | YES      |        | general/battle/timer 等 |
-| is_unlocked             | INTEGER | YES      |        | 1:解除済, 0:未解除      |
-| unlocked_at             | TEXT    | NO       |        | 解除日時                |
-| created_at              | TEXT    | YES      |        | 作成日時                |
-| updated_at              | TEXT    | YES      |        | 更新日時                |
+| カラム名                | 型      | NOT NULL | 主キー | 備考                            |
+| ----------------------- | ------- | -------- | ------ | ------------------------------- |
+| id                      | INTEGER | YES      | YES    | 自動採番 ID                     |
+| achievement_id          | TEXT    | YES      | UNIQUE | 識別子                          |
+| achievement_name        | TEXT    | YES      |        | 名前                            |
+| achievement_description | TEXT    | YES      |        | 説明                            |
+| achievement_category    | TEXT    | YES      |        | stage/battle/item/timer/special |
+| achievement_type        | TEXT    | YES      |        | progress/milestone/hidden など  |
+| target_value            | INTEGER | NO       |        | 目標値（数値系実績用）          |
+| current_progress        | INTEGER | YES      |        | 現在の進捗                      |
+| is_unlocked             | INTEGER | YES      |        | 1:解除済, 0:未解除              |
+| reward_items            | TEXT    | NO       |        | 報酬アイテム（JSON）            |
+| unlocked_at             | TEXT    | NO       |        | 解除日時                        |
+| created_at              | TEXT    | YES      |        | 作成日時                        |
+| updated_at              | TEXT    | YES      |        | 更新日時                        |
+
+#### 2.12 `tutorial_progress` テーブル（新規）
+
+| カラム名         | 型      | NOT NULL | 主キー | 備考                     |
+| ---------------- | ------- | -------- | ------ | ------------------------ |
+| id               | INTEGER | YES      | YES    | 自動採番 ID              |
+| tutorial_id      | TEXT    | YES      | UNIQUE | チュートリアル識別子     |
+| tutorial_name    | TEXT    | YES      |        | チュートリアル名         |
+| is_completed     | INTEGER | YES      |        | 1:完了, 0:未完了         |
+| current_step     | INTEGER | YES      |        | 現在のステップ           |
+| total_steps      | INTEGER | YES      |        | 総ステップ数             |
+| completion_rate  | REAL    | YES      |        | 完了率（0〜1）           |
+| started_at       | TEXT    | NO       |        | 開始日時                 |
+| completed_at     | TEXT    | NO       |        | 完了日時                 |
+| last_accessed_at | TEXT    | YES      |        | 最終アクセス日時         |
+| created_at       | TEXT    | YES      |        | 作成日時                 |
+| updated_at       | TEXT    | YES      |        | 更新日時                 |
 
 ---
 
-### 3. ER 図（簡易）
+### 3. ER 図（修正版）
 
 ```
-game_progress --< battle_history --< timer_history
-                               |         |
-                               |         --> penalty_records
-                               --> victory_claims
+game_progress --< stages --< battle_sessions --< timer_history
+                  |              |                  |
+                  |              |                  --> penalty_records
+                  |              --> temp_rewards
+                  |              --> victory_claims
+                  |              --> item_consumption_log
+                  |
+                  --> tutorial_progress
 
-battle_history --< power_enemy_encounters
-prime_inventory --< battle_history
+item_inventory --< battle_sessions
+power_enemy_encounters --< battle_sessions
 achievements --< game_progress
-tutorial_progress -- game_progress
 ```
 
 ---
 
-### 4. 備考
+### 4. 新機能対応の設計ポイント
 
-- TEXT 型の日付は ISO 8601 形式で格納
-- boolean 相当は INTEGER（0 または 1）で表現
-- 外部キー制約は ON（SQLite 設定で明示）
-- `primes_used`などの配列データは JSON 文字列形式で保持
+#### 4.1 ステージシステム
+- `stages`テーブルでステージ情報を管理
+- スロット制限、時間制限、解放条件を設定
+- ステージ別の統計情報を追跡
+
+#### 4.2 アイテム消費システム
+- `item_consumption_log`でアイテム使用を詳細記録
+- 成功/失敗に関わらず消費を記録
+- 消費理由と攻撃結果を分離管理
+
+#### 4.3 仮報酬システム
+- `temp_rewards`で一時的な報酬を管理
+- ステージクリア時の確定処理を追跡
+- 失敗時の破棄処理も記録
+
+#### 4.4 拡張された統計
+- ステージ別クリア率
+- アイテム消費効率
+- 仮報酬の確定/破棄比率
 
 ---
 
 ### 5. SQL DDL（CREATE TABLE 文）
 
 ```sql
--- game_progress
+-- game_progress（更新）
 CREATE TABLE game_progress (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   player_level INTEGER NOT NULL,
+  current_stage INTEGER NOT NULL,
+  max_unlocked_stage INTEGER NOT NULL,
   total_experience INTEGER NOT NULL,
   total_battles INTEGER NOT NULL,
   total_victories INTEGER NOT NULL,
-  total_primes_collected INTEGER NOT NULL,
+  total_stage_clears INTEGER NOT NULL,
+  total_stage_failures INTEGER NOT NULL,
+  total_items_collected INTEGER NOT NULL,
+  total_items_consumed INTEGER NOT NULL,
   total_power_enemies_defeated INTEGER NOT NULL,
   total_time_penalties INTEGER NOT NULL,
   win_rate REAL NOT NULL,
+  stage_clear_rate REAL NOT NULL,
   victory_claim_accuracy REAL NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
 
--- prime_inventory
-CREATE TABLE prime_inventory (
+-- stages（新規）
+CREATE TABLE stages (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  prime_value INTEGER NOT NULL UNIQUE,
-  count INTEGER NOT NULL,
-  total_obtained INTEGER NOT NULL,
-  usage_count INTEGER NOT NULL,
-  power_enemy_rewards INTEGER NOT NULL,
-  first_obtained_at TEXT NOT NULL,
-  last_used_at TEXT,
+  stage_number INTEGER NOT NULL UNIQUE,
+  stage_name TEXT NOT NULL,
+  stage_description TEXT NOT NULL,
+  stage_type TEXT NOT NULL,
+  difficulty_level TEXT NOT NULL,
+  slot_limit INTEGER NOT NULL,
+  base_time_seconds INTEGER NOT NULL,
+  enemy_count INTEGER NOT NULL,
+  min_enemy_value INTEGER NOT NULL,
+  max_enemy_value INTEGER NOT NULL,
+  is_unlocked INTEGER NOT NULL,
+  unlock_condition TEXT,
+  rewards TEXT NOT NULL,
+  best_clear_time_ms INTEGER,
+  total_attempts INTEGER NOT NULL,
+  total_clears INTEGER NOT NULL,
+  first_unlocked_at TEXT,
+  first_cleared_at TEXT,
+  last_attempted_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
 
--- battle_history
-CREATE TABLE battle_history (
+-- item_inventory（更新）
+CREATE TABLE item_inventory (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_value INTEGER NOT NULL UNIQUE,
+  item_type TEXT NOT NULL,
+  count INTEGER NOT NULL,
+  total_obtained INTEGER NOT NULL,
+  total_consumed INTEGER NOT NULL,
+  battle_usage_count INTEGER NOT NULL,
+  power_enemy_rewards INTEGER NOT NULL,
+  stage_rewards INTEGER NOT NULL,
+  temp_rewards INTEGER NOT NULL,
+  first_obtained_at TEXT NOT NULL,
+  last_used_at TEXT,
+  last_obtained_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- battle_sessions（更新）
+CREATE TABLE battle_sessions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  stage_id INTEGER NOT NULL,
   enemy_original_value INTEGER NOT NULL,
   enemy_final_value INTEGER NOT NULL,
   enemy_type TEXT NOT NULL,
   is_power_enemy INTEGER NOT NULL,
   power_base INTEGER,
   power_exponent INTEGER,
+  loadout_items TEXT NOT NULL,
+  items_consumed TEXT NOT NULL,
   turn_count INTEGER NOT NULL,
+  attack_count INTEGER NOT NULL,
+  successful_attacks INTEGER NOT NULL,
+  failed_attacks INTEGER NOT NULL,
+  prime_attacks INTEGER NOT NULL,
   battle_duration_ms INTEGER NOT NULL,
   timer_remaining_seconds INTEGER,
-  battle_result TEXT NOT NULL,
-  primes_used TEXT NOT NULL,
-  reward_prime INTEGER,
-  reward_count INTEGER NOT NULL,
+  session_result TEXT NOT NULL,
+  temp_rewards_json TEXT NOT NULL,
+  finalized_rewards_json TEXT,
   victory_claim_correct INTEGER,
   victory_claim_attempts INTEGER NOT NULL,
-  battle_date TEXT NOT NULL,
-  created_at TEXT NOT NULL
+  session_date TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(stage_id) REFERENCES stages(id) ON DELETE CASCADE
 );
 
--- timer_history
+-- temp_rewards（新規）
+CREATE TABLE temp_rewards (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id INTEGER NOT NULL,
+  item_value INTEGER NOT NULL,
+  item_count INTEGER NOT NULL,
+  reward_source TEXT NOT NULL,
+  source_enemy_value INTEGER,
+  is_finalized INTEGER NOT NULL,
+  obtained_at TEXT NOT NULL,
+  finalized_at TEXT,
+  discarded_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(session_id) REFERENCES battle_sessions(id) ON DELETE CASCADE
+);
+
+-- item_consumption_log（新規）
+CREATE TABLE item_consumption_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id INTEGER NOT NULL,
+  item_value INTEGER NOT NULL,
+  consumption_reason TEXT NOT NULL,
+  target_enemy_value INTEGER NOT NULL,
+  attack_successful INTEGER NOT NULL,
+  turn_number INTEGER NOT NULL,
+  consumed_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(session_id) REFERENCES battle_sessions(id) ON DELETE CASCADE
+);
+
+-- timer_history（更新）
 CREATE TABLE timer_history (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  battle_id INTEGER NOT NULL,
+  session_id INTEGER NOT NULL,
+  stage_id INTEGER NOT NULL,
   original_seconds INTEGER NOT NULL,
   final_seconds INTEGER NOT NULL,
   penalty_seconds INTEGER NOT NULL,
@@ -229,58 +427,90 @@ CREATE TABLE timer_history (
   timer_start_at TEXT NOT NULL,
   timer_end_at TEXT,
   created_at TEXT NOT NULL,
-  FOREIGN KEY(battle_id) REFERENCES battle_history(id) ON DELETE CASCADE
+  FOREIGN KEY(session_id) REFERENCES battle_sessions(id) ON DELETE CASCADE,
+  FOREIGN KEY(stage_id) REFERENCES stages(id)
 );
 
--- penalty_records
+-- penalty_records（更新）
 CREATE TABLE penalty_records (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  battle_id INTEGER,
+  session_id INTEGER,
+  stage_id INTEGER NOT NULL,
   penalty_type TEXT NOT NULL,
   penalty_seconds INTEGER NOT NULL,
   penalty_reason TEXT NOT NULL,
   applied_at TEXT NOT NULL,
   created_at TEXT NOT NULL,
-  FOREIGN KEY(battle_id) REFERENCES battle_history(id)
+  FOREIGN KEY(session_id) REFERENCES battle_sessions(id),
+  FOREIGN KEY(stage_id) REFERENCES stages(id)
 );
 
--- victory_claims
+-- victory_claims（更新）
 CREATE TABLE victory_claims (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  battle_id INTEGER NOT NULL,
+  session_id INTEGER NOT NULL,
+  stage_id INTEGER NOT NULL,
   claimed_value INTEGER NOT NULL,
+  actual_value INTEGER NOT NULL,
   is_correct INTEGER NOT NULL,
   penalty_applied INTEGER NOT NULL,
+  reward_obtained INTEGER,
   claimed_at TEXT NOT NULL,
   created_at TEXT NOT NULL,
-  FOREIGN KEY(battle_id) REFERENCES battle_history(id) ON DELETE CASCADE
+  FOREIGN KEY(session_id) REFERENCES battle_sessions(id) ON DELETE CASCADE,
+  FOREIGN KEY(stage_id) REFERENCES stages(id)
 );
 
--- power_enemy_encounters
+-- power_enemy_encounters（更新）
 CREATE TABLE power_enemy_encounters (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   enemy_value INTEGER NOT NULL UNIQUE,
   power_base INTEGER NOT NULL,
   power_exponent INTEGER NOT NULL,
+  stage_first_encountered INTEGER NOT NULL,
   player_level_at_encounter INTEGER NOT NULL,
-  was_defeated INTEGER NOT NULL,
+  total_encounters INTEGER NOT NULL,
+  total_defeats INTEGER NOT NULL,
   attempts_count INTEGER NOT NULL,
   rewards_obtained INTEGER NOT NULL,
+  temp_rewards_lost INTEGER NOT NULL,
   first_encounter_at TEXT NOT NULL,
   last_encounter_at TEXT NOT NULL,
+  first_defeat_at TEXT,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(stage_first_encountered) REFERENCES stages(id)
 );
 
--- achievements
+-- achievements（更新）
 CREATE TABLE achievements (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   achievement_id TEXT NOT NULL UNIQUE,
   achievement_name TEXT NOT NULL,
   achievement_description TEXT NOT NULL,
   achievement_category TEXT NOT NULL,
+  achievement_type TEXT NOT NULL,
+  target_value INTEGER,
+  current_progress INTEGER NOT NULL,
   is_unlocked INTEGER NOT NULL,
+  reward_items TEXT,
   unlocked_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- tutorial_progress（新規）
+CREATE TABLE tutorial_progress (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  tutorial_id TEXT NOT NULL UNIQUE,
+  tutorial_name TEXT NOT NULL,
+  is_completed INTEGER NOT NULL,
+  current_step INTEGER NOT NULL,
+  total_steps INTEGER NOT NULL,
+  completion_rate REAL NOT NULL,
+  started_at TEXT,
+  completed_at TEXT,
+  last_accessed_at TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -288,83 +518,540 @@ CREATE TABLE achievements (
 
 ---
 
-### 6. クエリ最適化戦略
+### 6. クエリ最適化戦略（更新）
 
 #### 6.1 インデックス
 
 ```sql
-CREATE INDEX idx_battle_result_date ON battle_history(battle_result, battle_date);
-CREATE INDEX idx_primes_available ON prime_inventory(count);
+-- 既存のインデックス
+CREATE INDEX idx_session_result_date ON battle_sessions(session_result, session_date);
+CREATE INDEX idx_items_available ON item_inventory(count);
 CREATE INDEX idx_timer_timeout ON timer_history(timed_out);
 CREATE INDEX idx_penalty_type ON penalty_records(penalty_type);
 CREATE INDEX idx_claim_accuracy ON victory_claims(is_correct);
 CREATE INDEX idx_power_enemy_base ON power_enemy_encounters(power_base);
+
+-- 新規インデックス
+CREATE INDEX idx_stages_unlocked ON stages(is_unlocked, stage_number);
+CREATE INDEX idx_stages_difficulty ON stages(difficulty_level, stage_type);
+CREATE INDEX idx_temp_rewards_finalized ON temp_rewards(is_finalized, session_id);
+CREATE INDEX idx_item_consumption_reason ON item_consumption_log(consumption_reason, attack_successful);
+CREATE INDEX idx_tutorial_completion ON tutorial_progress(is_completed, tutorial_id);
+CREATE INDEX idx_achievements_category ON achievements(achievement_category, is_unlocked);
+CREATE INDEX idx_sessions_stage ON battle_sessions(stage_id, session_result);
 ```
 
 #### 6.2 推奨クエリ構成
 
-- 集計クエリでは `COUNT(*)`, `AVG()` 等を使用する場合、必要なカラムに限定する
-- `JOIN` を避け、`WHERE battle_id = ?` による個別参照を優先
-- JSON 配列の検索を行う場合はアプリ側で展開して処理
+```sql
+-- ステージ別統計
+SELECT 
+  s.stage_number,
+  s.stage_name,
+  COUNT(bs.id) as total_attempts,
+  SUM(CASE WHEN bs.session_result = 'stageComplete' THEN 1 ELSE 0 END) as clears,
+  AVG(bs.battle_duration_ms) as avg_duration
+FROM stages s
+LEFT JOIN battle_sessions bs ON s.id = bs.stage_id
+WHERE s.is_unlocked = 1
+GROUP BY s.id
+ORDER BY s.stage_number;
+
+-- アイテム消費効率
+SELECT 
+  ii.item_value,
+  ii.total_consumed,
+  SUM(CASE WHEN icl.attack_successful = 1 THEN 1 ELSE 0 END) as successful_uses,
+  CAST(SUM(CASE WHEN icl.attack_successful = 1 THEN 1 ELSE 0 END) AS REAL) / ii.total_consumed as efficiency
+FROM item_inventory ii
+JOIN item_consumption_log icl ON ii.item_value = icl.item_value
+WHERE ii.total_consumed > 0
+GROUP BY ii.item_value
+ORDER BY efficiency DESC;
+
+-- 仮報酬の確定/破棄統計
+SELECT 
+  reward_source,
+  COUNT(*) as total_temp_rewards,
+  SUM(CASE WHEN is_finalized = 1 THEN 1 ELSE 0 END) as finalized_count,
+  SUM(CASE WHEN discarded_at IS NOT NULL THEN 1 ELSE 0 END) as discarded_count,
+  AVG(item_count) as avg_reward_count
+FROM temp_rewards
+GROUP BY reward_source;
+
+-- プレイヤー進捗サマリー
+SELECT 
+  gp.player_level,
+  gp.current_stage,
+  gp.total_stage_clears,
+  gp.total_stage_failures,
+  gp.stage_clear_rate,
+  COUNT(DISTINCT s.id) as unlocked_stages,
+  ii_summary.total_items,
+  ii_summary.unique_items
+FROM game_progress gp
+CROSS JOIN (
+  SELECT 
+    SUM(count) as total_items,
+    COUNT(*) as unique_items
+  FROM item_inventory 
+  WHERE count > 0
+) ii_summary
+LEFT JOIN stages s ON s.is_unlocked = 1;
+```
 
 ---
 
-### 7. Flutter 用 DAO/Model 設計（一部例）
+### 7. Flutter 用 Model 設計（主要クラス）
 
-#### 7.1 `PrimeInventoryModel`
+#### 7.1 `StageModel`（新規）
 
 ```dart
-class PrimeInventoryModel {
+class StageModel {
   final int id;
-  final int primeValue;
-  final int count;
-  final int totalObtained;
-  final int usageCount;
-  final int powerEnemyRewards;
-  final DateTime firstObtainedAt;
-  final DateTime? lastUsedAt;
+  final int stageNumber;
+  final String stageName;
+  final String stageDescription;
+  final String stageType;
+  final String difficultyLevel;
+  final int slotLimit;
+  final int baseTimeSeconds;
+  final int enemyCount;
+  final int minEnemyValue;
+  final int maxEnemyValue;
+  final bool isUnlocked;
+  final String? unlockCondition;
+  final String rewards;
+  final int? bestClearTimeMs;
+  final int totalAttempts;
+  final int totalClears;
+  final DateTime? firstUnlockedAt;
+  final DateTime? firstClearedAt;
+  final DateTime? lastAttemptedAt;
   final DateTime createdAt;
   final DateTime updatedAt;
 
-  PrimeInventoryModel({
+  StageModel({
     required this.id,
-    required this.primeValue,
-    required this.count,
-    required this.totalObtained,
-    required this.usageCount,
-    required this.powerEnemyRewards,
-    required this.firstObtainedAt,
-    this.lastUsedAt,
+    required this.stageNumber,
+    required this.stageName,
+    required this.stageDescription,
+    required this.stageType,
+    required this.difficultyLevel,
+    required this.slotLimit,
+    required this.baseTimeSeconds,
+    required this.enemyCount,
+    required this.minEnemyValue,
+    required this.maxEnemyValue,
+    required this.isUnlocked,
+    this.unlockCondition,
+    required this.rewards,
+    this.bestClearTimeMs,
+    required this.totalAttempts,
+    required this.totalClears,
+    this.firstUnlockedAt,
+    this.firstClearedAt,
+    this.lastAttemptedAt,
     required this.createdAt,
     required this.updatedAt,
   });
 
-  factory PrimeInventoryModel.fromMap(Map<String, dynamic> map) => PrimeInventoryModel(
+  factory StageModel.fromMap(Map<String, dynamic> map) => StageModel(
     id: map['id'],
-    primeValue: map['prime_value'],
-    count: map['count'],
-    totalObtained: map['total_obtained'],
-    usageCount: map['usage_count'],
-    powerEnemyRewards: map['power_enemy_rewards'],
-    firstObtainedAt: DateTime.parse(map['first_obtained_at']),
-    lastUsedAt: map['last_used_at'] != null ? DateTime.parse(map['last_used_at']) : null,
+    stageNumber: map['stage_number'],
+    stageName: map['stage_name'],
+    stageDescription: map['stage_description'],
+    stageType: map['stage_type'],
+    difficultyLevel: map['difficulty_level'],
+    slotLimit: map['slot_limit'],
+    baseTimeSeconds: map['base_time_seconds'],
+    enemyCount: map['enemy_count'],
+    minEnemyValue: map['min_enemy_value'],
+    maxEnemyValue: map['max_enemy_value'],
+    isUnlocked: map['is_unlocked'] == 1,
+    unlockCondition: map['unlock_condition'],
+    rewards: map['rewards'],
+    bestClearTimeMs: map['best_clear_time_ms'],
+    totalAttempts: map['total_attempts'],
+    totalClears: map['total_clears'],
+    firstUnlockedAt: map['first_unlocked_at'] != null 
+        ? DateTime.parse(map['first_unlocked_at']) : null,
+    firstClearedAt: map['first_cleared_at'] != null 
+        ? DateTime.parse(map['first_cleared_at']) : null,
+    lastAttemptedAt: map['last_attempted_at'] != null 
+        ? DateTime.parse(map['last_attempted_at']) : null,
     createdAt: DateTime.parse(map['created_at']),
     updatedAt: DateTime.parse(map['updated_at']),
   );
 
   Map<String, dynamic> toMap() => {
     'id': id,
-    'prime_value': primeValue,
-    'count': count,
-    'total_obtained': totalObtained,
-    'usage_count': usageCount,
-    'power_enemy_rewards': powerEnemyRewards,
-    'first_obtained_at': firstObtainedAt.toIso8601String(),
-    'last_used_at': lastUsedAt?.toIso8601String(),
+    'stage_number': stageNumber,
+    'stage_name': stageName,
+    'stage_description': stageDescription,
+    'stage_type': stageType,
+    'difficulty_level': difficultyLevel,
+    'slot_limit': slotLimit,
+    'base_time_seconds': baseTimeSeconds,
+    'enemy_count': enemyCount,
+    'min_enemy_value': minEnemyValue,
+    'max_enemy_value': maxEnemyValue,
+    'is_unlocked': isUnlocked ? 1 : 0,
+    'unlock_condition': unlockCondition,
+    'rewards': rewards,
+    'best_clear_time_ms': bestClearTimeMs,
+    'total_attempts': totalAttempts,
+    'total_clears': totalClears,
+    'first_unlocked_at': firstUnlockedAt?.toIso8601String(),
+    'first_cleared_at': firstClearedAt?.toIso8601String(),
+    'last_attempted_at': lastAttemptedAt?.toIso8601String(),
     'created_at': createdAt.toIso8601String(),
     'updated_at': updatedAt.toIso8601String(),
   };
+
+  double get clearRate => totalAttempts > 0 ? totalClears / totalAttempts : 0.0;
+  bool get hasBeenAttempted => totalAttempts > 0;
+  bool get hasBeenCleared => totalClears > 0;
 }
 ```
 
-※ 他モデルや DAO についても同様に定義可能。必要であれば続きも提供可能です。
+#### 7.2 `ItemInventoryModel`（更新版）
+
+```dart
+class ItemInventoryModel {
+  final int id;
+  final int itemValue;
+  final String itemType;
+  final int count;
+  final int totalObtained;
+  final int totalConsumed;
+  final int battleUsageCount;
+  final int powerEnemyRewards;
+  final int stageRewards;
+  final int tempRewards;
+  final DateTime firstObtainedAt;
+  final DateTime? lastUsedAt;
+  final DateTime lastObtainedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  ItemInventoryModel({
+    required this.id,
+    required this.itemValue,
+    required this.itemType,
+    required this.count,
+    required this.totalObtained,
+    required this.totalConsumed,
+    required this.battleUsageCount,
+    required this.powerEnemyRewards,
+    required this.stageRewards,
+    required this.tempRewards,
+    required this.firstObtainedAt,
+    this.lastUsedAt,
+    required this.lastObtainedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory ItemInventoryModel.fromMap(Map<String, dynamic> map) => ItemInventoryModel(
+    id: map['id'],
+    itemValue: map['item_value'],
+    itemType: map['item_type'],
+    count: map['count'],
+    totalObtained: map['total_obtained'],
+    totalConsumed: map['total_consumed'],
+    battleUsageCount: map['battle_usage_count'],
+    powerEnemyRewards: map['power_enemy_rewards'],
+    stageRewards: map['stage_rewards'],
+    tempRewards: map['temp_rewards'],
+    firstObtainedAt: DateTime.parse(map['first_obtained_at']),
+    lastUsedAt: map['last_used_at'] != null 
+        ? DateTime.parse(map['last_used_at']) : null,
+    lastObtainedAt: DateTime.parse(map['last_obtained_at']),
+    createdAt: DateTime.parse(map['created_at']),
+    updatedAt: DateTime.parse(map['updated_at']),
+  );
+
+  Map<String, dynamic> toMap() => {
+    'id': id,
+    'item_value': itemValue,
+    'item_type': itemType,
+    'count': count,
+    'total_obtained': totalObtained,
+    'total_consumed': totalConsumed,
+    'battle_usage_count': battleUsageCount,
+    'power_enemy_rewards': powerEnemyRewards,
+    'stage_rewards': stageRewards,
+    'temp_rewards': tempRewards,
+    'first_obtained_at': firstObtainedAt.toIso8601String(),
+    'last_used_at': lastUsedAt?.toIso8601String(),
+    'last_obtained_at': lastObtainedAt.toIso8601String(),
+    'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
+  };
+
+  bool get isAvailable => count > 0;
+  bool get isPrime => itemType == 'prime';
+  double get consumptionRate => totalObtained > 0 ? totalConsumed / totalObtained : 0.0;
+  double get usageEfficiency => totalConsumed > 0 ? battleUsageCount / totalConsumed : 0.0;
+}
+```
+
+#### 7.3 `TempRewardModel`（新規）
+
+```dart
+class TempRewardModel {
+  final int id;
+  final int sessionId;
+  final int itemValue;
+  final int itemCount;
+  final String rewardSource;
+  final int? sourceEnemyValue;
+  final bool isFinalized;
+  final DateTime obtainedAt;
+  final DateTime? finalizedAt;
+  final DateTime? discardedAt;
+  final DateTime createdAt;
+
+  TempRewardModel({
+    required this.id,
+    required this.sessionId,
+    required this.itemValue,
+    required this.itemCount,
+    required this.rewardSource,
+    this.sourceEnemyValue,
+    required this.isFinalized,
+    required this.obtainedAt,
+    this.finalizedAt,
+    this.discardedAt,
+    required this.createdAt,
+  });
+
+  factory TempRewardModel.fromMap(Map<String, dynamic> map) => TempRewardModel(
+    id: map['id'],
+    sessionId: map['session_id'],
+    itemValue: map['item_value'],
+    itemCount: map['item_count'],
+    rewardSource: map['reward_source'],
+    sourceEnemyValue: map['source_enemy_value'],
+    isFinalized: map['is_finalized'] == 1,
+    obtainedAt: DateTime.parse(map['obtained_at']),
+    finalizedAt: map['finalized_at'] != null 
+        ? DateTime.parse(map['finalized_at']) : null,
+    discardedAt: map['discarded_at'] != null 
+        ? DateTime.parse(map['discarded_at']) : null,
+    createdAt: DateTime.parse(map['created_at']),
+  );
+
+  Map<String, dynamic> toMap() => {
+    'id': id,
+    'session_id': sessionId,
+    'item_value': itemValue,
+    'item_count': itemCount,
+    'reward_source': rewardSource,
+    'source_enemy_value': sourceEnemyValue,
+    'is_finalized': isFinalized ? 1 : 0,
+    'obtained_at': obtainedAt.toIso8601String(),
+    'finalized_at': finalizedAt?.toIso8601String(),
+    'discarded_at': discardedAt?.toIso8601String(),
+    'created_at': createdAt.toIso8601String(),
+  };
+
+  bool get isPending => !isFinalized && discardedAt == null;
+  bool get wasDiscarded => discardedAt != null;
+  bool get wasFinalized => isFinalized && finalizedAt != null;
+}
+```
+
+#### 7.4 `BattleSessionModel`（更新版）
+
+```dart
+class BattleSessionModel {
+  final int id;
+  final int stageId;
+  final int enemyOriginalValue;
+  final int enemyFinalValue;
+  final String enemyType;
+  final bool isPowerEnemy;
+  final int? powerBase;
+  final int? powerExponent;
+  final String loadoutItems;
+  final String itemsConsumed;
+  final int turnCount;
+  final int attackCount;
+  final int successfulAttacks;
+  final int failedAttacks;
+  final int primeAttacks;
+  final int battleDurationMs;
+  final int? timerRemainingSeconds;
+  final String sessionResult;
+  final String tempRewardsJson;
+  final String? finalizedRewardsJson;
+  final bool? victoryClaimCorrect;
+  final int victoryClaimAttempts;
+  final DateTime sessionDate;
+  final DateTime createdAt;
+
+  BattleSessionModel({
+    required this.id,
+    required this.stageId,
+    required this.enemyOriginalValue,
+    required this.enemyFinalValue,
+    required this.enemyType,
+    required this.isPowerEnemy,
+    this.powerBase,
+    this.powerExponent,
+    required this.loadoutItems,
+    required this.itemsConsumed,
+    required this.turnCount,
+    required this.attackCount,
+    required this.successfulAttacks,
+    required this.failedAttacks,
+    required this.primeAttacks,
+    required this.battleDurationMs,
+    this.timerRemainingSeconds,
+    required this.sessionResult,
+    required this.tempRewardsJson,
+    this.finalizedRewardsJson,
+    this.victoryClaimCorrect,
+    required this.victoryClaimAttempts,
+    required this.sessionDate,
+    required this.createdAt,
+  });
+
+  factory BattleSessionModel.fromMap(Map<String, dynamic> map) => BattleSessionModel(
+    id: map['id'],
+    stageId: map['stage_id'],
+    enemyOriginalValue: map['enemy_original_value'],
+    enemyFinalValue: map['enemy_final_value'],
+    enemyType: map['enemy_type'],
+    isPowerEnemy: map['is_power_enemy'] == 1,
+    powerBase: map['power_base'],
+    powerExponent: map['power_exponent'],
+    loadoutItems: map['loadout_items'],
+    itemsConsumed: map['items_consumed'],
+    turnCount: map['turn_count'],
+    attackCount: map['attack_count'],
+    successfulAttacks: map['successful_attacks'],
+    failedAttacks: map['failed_attacks'],
+    primeAttacks: map['prime_attacks'],
+    battleDurationMs: map['battle_duration_ms'],
+    timerRemainingSeconds: map['timer_remaining_seconds'],
+    sessionResult: map['session_result'],
+    tempRewardsJson: map['temp_rewards_json'],
+    finalizedRewardsJson: map['finalized_rewards_json'],
+    victoryClaimCorrect: map['victory_claim_correct'] == 1,
+    victoryClaimAttempts: map['victory_claim_attempts'],
+    sessionDate: DateTime.parse(map['session_date']),
+    createdAt: DateTime.parse(map['created_at']),
+  );
+
+  Map<String, dynamic> toMap() => {
+    'id': id,
+    'stage_id': stageId,
+    'enemy_original_value': enemyOriginalValue,
+    'enemy_final_value': enemyFinalValue,
+    'enemy_type': enemyType,
+    'is_power_enemy': isPowerEnemy ? 1 : 0,
+    'power_base': powerBase,
+    'power_exponent': powerExponent,
+    'loadout_items': loadoutItems,
+    'items_consumed': itemsConsumed,
+    'turn_count': turnCount,
+    'attack_count': attackCount,
+    'successful_attacks': successfulAttacks,
+    'failed_attacks': failedAttacks,
+    'prime_attacks': primeAttacks,
+    'battle_duration_ms': battleDurationMs,
+    'timer_remaining_seconds': timerRemainingSeconds,
+    'session_result': sessionResult,
+    'temp_rewards_json': tempRewardsJson,
+    'finalized_rewards_json': finalizedRewardsJson,
+    'victory_claim_correct': victoryClaimCorrect == true ? 1 : 0,
+    'victory_claim_attempts': victoryClaimAttempts,
+    'session_date': sessionDate.toIso8601String(),
+    'created_at': createdAt.toIso8601String(),
+  };
+
+  bool get wasSuccessful => sessionResult == 'stageComplete';
+  bool get wasFailed => sessionResult == 'stageFailed';
+  double get attackSuccessRate => attackCount > 0 ? successfulAttacks / attackCount : 0.0;
+  double get itemEfficiency => attackCount > 0 ? successfulAttacks / attackCount : 0.0;
+  bool get hadPrimeAttacks => primeAttacks > 0;
+}
+```
+
+---
+
+### 8. データマイグレーション戦略
+
+#### 8.1 バージョン管理
+
+```sql
+-- データベースバージョン管理テーブル
+CREATE TABLE db_version (
+  version INTEGER PRIMARY KEY,
+  migration_date TEXT NOT NULL,
+  description TEXT NOT NULL
+);
+
+-- 初期バージョン挿入
+INSERT INTO db_version (version, migration_date, description)
+VALUES (4, datetime('now'), 'Stage system and item consumption update');
+```
+
+#### 8.2 マイグレーション手順
+
+```dart
+class DatabaseMigration {
+  static Future<void> migrateToV4(Database db) async {
+    await db.transaction((txn) async {
+      // 1. 新しいテーブル作成
+      await txn.execute('''
+        CREATE TABLE stages_new AS SELECT * FROM stages_template;
+      ''');
+      
+      // 2. 既存データの移行
+      await txn.execute('''
+        INSERT INTO item_inventory (item_value, item_type, count, total_obtained, ...)
+        SELECT prime_value, 'prime', count, total_obtained, ...
+        FROM prime_inventory;
+      ''');
+      
+      // 3. 古いテーブル削除
+      await txn.execute('DROP TABLE IF EXISTS prime_inventory;');
+      
+      // 4. テーブル名変更
+      await txn.execute('ALTER TABLE stages_new RENAME TO stages;');
+      
+      // 5. インデックス再作成
+      await _createIndexes(txn);
+    });
+  }
+  
+  static Future<void> _createIndexes(Transaction txn) async {
+    // インデックス作成処理
+  }
+}
+```
+
+---
+
+### 9. パフォーマンス考慮事項
+
+#### 9.1 データ量予測
+- **アクティブユーザー**: 10,000人
+- **1日あたりの戦闘セッション**: 平均50回/ユーザー
+- **1年間のデータ蓄積**: 約182万レコード（battle_sessions）
+- **データベースサイズ**: 約100MB（インデックス含む）
+
+#### 9.2 最適化戦略
+- **パーティショニング**: 日付ベースの論理分割
+- **アーカイブ**: 古いデータの圧縮保存
+- **キャッシュ**: 頻繁にアクセスされるデータのメモリ保持
+
+#### 9.3 監視項目
+- クエリ実行時間
+- データベースサイズ
+- インデックス使用率
+- ディスク I/O パフォーマンス

--- a/lib/core/utils/math_utils.dart
+++ b/lib/core/utils/math_utils.dart
@@ -81,6 +81,25 @@ class MathUtils {
     return primeFactors.reduce((a, b) => a * b);
   }
 
+  /// Get all factors of a number
+  static List<int> getFactors(int n) {
+    if (n <= 1) return [];
+
+    final factors = <int>[];
+
+    for (int i = 1; i * i <= n; i++) {
+      if (n % i == 0) {
+        factors.add(i);
+        if (i != n ~/ i) {
+          factors.add(n ~/ i);
+        }
+      }
+    }
+
+    factors.sort();
+    return factors;
+  }
+
   /// Get the difficulty rating for a number based on its size and complexity
   static int getDifficulty(int n) {
     final factors = factorize(n);

--- a/lib/domain/entities/battle_loadout.dart
+++ b/lib/domain/entities/battle_loadout.dart
@@ -1,0 +1,66 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'prime.dart';
+import 'stage.dart';
+
+part 'battle_loadout.freezed.dart';
+
+@freezed
+class BattleLoadout with _$BattleLoadout {
+  const factory BattleLoadout({
+    required List<Item> battleItems,
+    required List<Item> originalItems,
+    required int maxSlots,
+    required Stage targetStage,
+    required DateTime createdAt,
+  }) = _BattleLoadout;
+
+  const BattleLoadout._();
+
+  /// Check if the loadout is full
+  bool get isFull => totalItemCount >= maxSlots;
+
+  /// Check if the loadout is empty
+  bool get isEmpty => battleItems.isEmpty;
+
+  /// Check if the battle can continue
+  bool get canContinueBattle => battleItems.any((item) => item.isAvailable);
+
+  /// Get remaining slots
+  int get remainingSlots => maxSlots - totalItemCount;
+
+  /// Get total item count
+  int get totalItemCount =>
+      battleItems.fold(0, (sum, item) => sum + item.count);
+
+  /// Use an item and return new loadout
+  BattleLoadout useItem(Item item) {
+    final updatedItems = battleItems.map((battleItem) {
+      if (battleItem.value == item.value) {
+        return battleItem.consume(1);
+      }
+      return battleItem;
+    }).toList();
+
+    return copyWith(battleItems: updatedItems);
+  }
+
+  /// Check if an item can be used
+  bool canUseItem(Item item) {
+    final battleItem = battleItems.firstWhere(
+      (battleItem) => battleItem.value == item.value,
+      orElse: () =>
+          Item(value: item.value, count: 0, firstObtained: DateTime.now()),
+    );
+    return battleItem.isAvailable;
+  }
+
+  /// Get remaining count for a specific item
+  int getRemainingCount(int itemValue) {
+    final battleItem = battleItems.firstWhere(
+      (battleItem) => battleItem.value == itemValue,
+      orElse: () =>
+          Item(value: itemValue, count: 0, firstObtained: DateTime.now()),
+    );
+    return battleItem.count;
+  }
+}

--- a/lib/domain/entities/battle_loadout.freezed.dart
+++ b/lib/domain/entities/battle_loadout.freezed.dart
@@ -1,0 +1,256 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'battle_loadout.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$BattleLoadout {
+  List<Item> get battleItems => throw _privateConstructorUsedError;
+  List<Item> get originalItems => throw _privateConstructorUsedError;
+  int get maxSlots => throw _privateConstructorUsedError;
+  Stage get targetStage => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BattleLoadoutCopyWith<BattleLoadout> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BattleLoadoutCopyWith<$Res> {
+  factory $BattleLoadoutCopyWith(
+          BattleLoadout value, $Res Function(BattleLoadout) then) =
+      _$BattleLoadoutCopyWithImpl<$Res, BattleLoadout>;
+  @useResult
+  $Res call(
+      {List<Item> battleItems,
+      List<Item> originalItems,
+      int maxSlots,
+      Stage targetStage,
+      DateTime createdAt});
+
+  $StageCopyWith<$Res> get targetStage;
+}
+
+/// @nodoc
+class _$BattleLoadoutCopyWithImpl<$Res, $Val extends BattleLoadout>
+    implements $BattleLoadoutCopyWith<$Res> {
+  _$BattleLoadoutCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? battleItems = null,
+    Object? originalItems = null,
+    Object? maxSlots = null,
+    Object? targetStage = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_value.copyWith(
+      battleItems: null == battleItems
+          ? _value.battleItems
+          : battleItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      originalItems: null == originalItems
+          ? _value.originalItems
+          : originalItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      maxSlots: null == maxSlots
+          ? _value.maxSlots
+          : maxSlots // ignore: cast_nullable_to_non_nullable
+              as int,
+      targetStage: null == targetStage
+          ? _value.targetStage
+          : targetStage // ignore: cast_nullable_to_non_nullable
+              as Stage,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $StageCopyWith<$Res> get targetStage {
+    return $StageCopyWith<$Res>(_value.targetStage, (value) {
+      return _then(_value.copyWith(targetStage: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$BattleLoadoutImplCopyWith<$Res>
+    implements $BattleLoadoutCopyWith<$Res> {
+  factory _$$BattleLoadoutImplCopyWith(
+          _$BattleLoadoutImpl value, $Res Function(_$BattleLoadoutImpl) then) =
+      __$$BattleLoadoutImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<Item> battleItems,
+      List<Item> originalItems,
+      int maxSlots,
+      Stage targetStage,
+      DateTime createdAt});
+
+  @override
+  $StageCopyWith<$Res> get targetStage;
+}
+
+/// @nodoc
+class __$$BattleLoadoutImplCopyWithImpl<$Res>
+    extends _$BattleLoadoutCopyWithImpl<$Res, _$BattleLoadoutImpl>
+    implements _$$BattleLoadoutImplCopyWith<$Res> {
+  __$$BattleLoadoutImplCopyWithImpl(
+      _$BattleLoadoutImpl _value, $Res Function(_$BattleLoadoutImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? battleItems = null,
+    Object? originalItems = null,
+    Object? maxSlots = null,
+    Object? targetStage = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_$BattleLoadoutImpl(
+      battleItems: null == battleItems
+          ? _value._battleItems
+          : battleItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      originalItems: null == originalItems
+          ? _value._originalItems
+          : originalItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      maxSlots: null == maxSlots
+          ? _value.maxSlots
+          : maxSlots // ignore: cast_nullable_to_non_nullable
+              as int,
+      targetStage: null == targetStage
+          ? _value.targetStage
+          : targetStage // ignore: cast_nullable_to_non_nullable
+              as Stage,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BattleLoadoutImpl extends _BattleLoadout {
+  const _$BattleLoadoutImpl(
+      {required final List<Item> battleItems,
+      required final List<Item> originalItems,
+      required this.maxSlots,
+      required this.targetStage,
+      required this.createdAt})
+      : _battleItems = battleItems,
+        _originalItems = originalItems,
+        super._();
+
+  final List<Item> _battleItems;
+  @override
+  List<Item> get battleItems {
+    if (_battleItems is EqualUnmodifiableListView) return _battleItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_battleItems);
+  }
+
+  final List<Item> _originalItems;
+  @override
+  List<Item> get originalItems {
+    if (_originalItems is EqualUnmodifiableListView) return _originalItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_originalItems);
+  }
+
+  @override
+  final int maxSlots;
+  @override
+  final Stage targetStage;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'BattleLoadout(battleItems: $battleItems, originalItems: $originalItems, maxSlots: $maxSlots, targetStage: $targetStage, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BattleLoadoutImpl &&
+            const DeepCollectionEquality()
+                .equals(other._battleItems, _battleItems) &&
+            const DeepCollectionEquality()
+                .equals(other._originalItems, _originalItems) &&
+            (identical(other.maxSlots, maxSlots) ||
+                other.maxSlots == maxSlots) &&
+            (identical(other.targetStage, targetStage) ||
+                other.targetStage == targetStage) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_battleItems),
+      const DeepCollectionEquality().hash(_originalItems),
+      maxSlots,
+      targetStage,
+      createdAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BattleLoadoutImplCopyWith<_$BattleLoadoutImpl> get copyWith =>
+      __$$BattleLoadoutImplCopyWithImpl<_$BattleLoadoutImpl>(this, _$identity);
+}
+
+abstract class _BattleLoadout extends BattleLoadout {
+  const factory _BattleLoadout(
+      {required final List<Item> battleItems,
+      required final List<Item> originalItems,
+      required final int maxSlots,
+      required final Stage targetStage,
+      required final DateTime createdAt}) = _$BattleLoadoutImpl;
+  const _BattleLoadout._() : super._();
+
+  @override
+  List<Item> get battleItems;
+  @override
+  List<Item> get originalItems;
+  @override
+  int get maxSlots;
+  @override
+  Stage get targetStage;
+  @override
+  DateTime get createdAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$BattleLoadoutImplCopyWith<_$BattleLoadoutImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/entities/battle_state.freezed.dart
+++ b/lib/domain/entities/battle_state.freezed.dart
@@ -17,7 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$BattleState {
   Enemy? get currentEnemy => throw _privateConstructorUsedError;
-  List<Prime> get usedPrimes => throw _privateConstructorUsedError;
+  List<Item> get usedPrimes => throw _privateConstructorUsedError;
   BattleStatus get status => throw _privateConstructorUsedError;
   int get turnCount => throw _privateConstructorUsedError;
   DateTime? get battleStartTime => throw _privateConstructorUsedError;
@@ -38,7 +38,7 @@ abstract class $BattleStateCopyWith<$Res> {
   @useResult
   $Res call(
       {Enemy? currentEnemy,
-      List<Prime> usedPrimes,
+      List<Item> usedPrimes,
       BattleStatus status,
       int turnCount,
       DateTime? battleStartTime,
@@ -81,7 +81,7 @@ class _$BattleStateCopyWithImpl<$Res, $Val extends BattleState>
       usedPrimes: null == usedPrimes
           ? _value.usedPrimes
           : usedPrimes // ignore: cast_nullable_to_non_nullable
-              as List<Prime>,
+              as List<Item>,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -156,7 +156,7 @@ abstract class _$$BattleStateImplCopyWith<$Res>
   @useResult
   $Res call(
       {Enemy? currentEnemy,
-      List<Prime> usedPrimes,
+      List<Item> usedPrimes,
       BattleStatus status,
       int turnCount,
       DateTime? battleStartTime,
@@ -200,7 +200,7 @@ class __$$BattleStateImplCopyWithImpl<$Res>
       usedPrimes: null == usedPrimes
           ? _value._usedPrimes
           : usedPrimes // ignore: cast_nullable_to_non_nullable
-              as List<Prime>,
+              as List<Item>,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -234,7 +234,7 @@ class __$$BattleStateImplCopyWithImpl<$Res>
 class _$BattleStateImpl extends _BattleState {
   const _$BattleStateImpl(
       {this.currentEnemy,
-      final List<Prime> usedPrimes = const [],
+      final List<Item> usedPrimes = const [],
       this.status = BattleStatus.waiting,
       this.turnCount = 0,
       this.battleStartTime,
@@ -247,10 +247,10 @@ class _$BattleStateImpl extends _BattleState {
 
   @override
   final Enemy? currentEnemy;
-  final List<Prime> _usedPrimes;
+  final List<Item> _usedPrimes;
   @override
   @JsonKey()
-  List<Prime> get usedPrimes {
+  List<Item> get usedPrimes {
     if (_usedPrimes is EqualUnmodifiableListView) return _usedPrimes;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_usedPrimes);
@@ -321,7 +321,7 @@ class _$BattleStateImpl extends _BattleState {
 abstract class _BattleState extends BattleState {
   const factory _BattleState(
       {final Enemy? currentEnemy,
-      final List<Prime> usedPrimes,
+      final List<Item> usedPrimes,
       final BattleStatus status,
       final int turnCount,
       final DateTime? battleStartTime,
@@ -333,7 +333,7 @@ abstract class _BattleState extends BattleState {
   @override
   Enemy? get currentEnemy;
   @override
-  List<Prime> get usedPrimes;
+  List<Item> get usedPrimes;
   @override
   BattleStatus get status;
   @override

--- a/lib/domain/entities/enemy.dart
+++ b/lib/domain/entities/enemy.dart
@@ -1,9 +1,22 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import '../../core/utils/math_utils.dart';
 import '../../core/exceptions/game_exception.dart';
-import '../../core/extensions/int_extensions.dart';
 
 part 'enemy.freezed.dart';
+
+enum EnemyType {
+  small,
+  medium,
+  large,
+  power,
+  special,
+}
+
+enum EnemySize {
+  small,
+  medium,
+  large,
+}
 
 @freezed
 class Enemy with _$Enemy {
@@ -19,65 +32,39 @@ class Enemy with _$Enemy {
 
   const Enemy._();
 
-  /// Check if the enemy can be attacked by the given prime
-  bool canBeAttackedBy(int prime) {
-    // Cannot attack if enemy is already defeated (prime number)
-    if (isDefeated) return false;
+  /// Check if the enemy is prime
+  bool get isPrime => MathUtils.isPrime(currentValue);
 
-    return currentValue % prime == 0;
+  /// Check if the enemy is defeated
+  bool get isDefeated => isPrime;
+
+  /// Check if the enemy is composite
+  bool get isComposite => !isPrime && currentValue > 1;
+
+  /// Get the enemy size based on original value
+  EnemySize get size {
+    if (originalValue <= 20) return EnemySize.small;
+    if (originalValue <= 100) return EnemySize.medium;
+    return EnemySize.large;
   }
 
-  /// Attack the enemy with the given prime
-  Enemy attack(int prime) {
-    if (!canBeAttackedBy(prime)) {
-      throw InvalidAttackException(
-        'Cannot attack $currentValue with $prime',
-        'Prime $prime does not divide $currentValue',
-      );
-    }
-
-    final newValue = currentValue ~/ prime;
-    return copyWith(currentValue: newValue);
-  }
-
-  /// Check if the enemy is defeated (reduced to a prime number)
-  bool get isDefeated => MathUtils.isPrime(currentValue);
-
-  /// Get the reward count for power enemies
-  int get powerRewardCount =>
-      isPowerEnemy && powerExponent != null ? powerExponent! : 1;
-
-  /// Get the reward prime for power enemies
-  int get powerRewardPrime =>
-      isPowerEnemy && powerBase != null ? powerBase! : currentValue;
-
-  /// Check if this enemy is a composite number
-  bool get isComposite => currentValue > 1 && !currentValue.isPrime;
-
-  /// Get the difficulty level of this enemy
+  /// Get difficulty rating for this enemy
   int get difficulty => MathUtils.getDifficulty(originalValue);
 
-  /// Get a list of available attacks (primes that can divide current value)
+  /// Get available attacks for this enemy
   List<int> get availableAttacks {
-    if (isDefeated) return [];
-
-    final factors = <int>[];
-    int n = currentValue;
-
-    // Find all prime factors of current value
-    for (int i = 2; i * i <= n; i++) {
-      if (n % i == 0) {
-        factors.add(i);
-        while (n % i == 0) {
-          n ~/= i;
-        }
-      }
-    }
-
-    if (n > 1) factors.add(n);
-
-    return factors;
+    if (isPrime) return [];
+    return MathUtils.getFactors(currentValue)
+        .where((f) => f > 1 && f < currentValue)
+        .toList();
   }
+
+  /// Get power reward prime (for power enemies)
+  int get powerRewardPrime =>
+      isPowerEnemy ? (powerBase ?? currentValue) : currentValue;
+
+  /// Get power reward count (for power enemies)
+  int get powerRewardCount => isPowerEnemy ? (powerExponent ?? 1) : 1;
 
   /// Get display information for UI
   String get displayInfo {
@@ -87,29 +74,86 @@ class Enemy with _$Enemy {
     return currentValue.toString();
   }
 
-  /// Get the enemy size category
-  EnemySize get size {
-    if (originalValue <= 20) return EnemySize.small;
-    if (originalValue <= 100) return EnemySize.medium;
-    return EnemySize.large;
+  /// Check if the enemy can be attacked by a value
+  bool canBeAttackedBy(int value) {
+    return !isPrime && currentValue % value == 0;
   }
 
-  @override
-  String toString() {
-    return 'Enemy(value: $currentValue, original: $originalValue, type: $type${isPowerEnemy ? ', power: $powerBase^$powerExponent' : ''})';
+  /// Attack the enemy with a value
+  Enemy attack(int value) {
+    if (!canBeAttackedBy(value)) {
+      throw InvalidAttackException('Cannot attack enemy with value $value');
+    }
+
+    final newValue = currentValue ~/ value;
+    return copyWith(currentValue: newValue);
   }
-}
 
-enum EnemyType {
-  small,
-  medium,
-  large,
-  power,
-  special,
-}
+  /// Create a power enemy
+  factory Enemy.power({
+    required int base,
+    required int exponent,
+    required EnemyType type,
+  }) {
+    final value = _power(base, exponent);
+    return Enemy(
+      currentValue: value,
+      originalValue: value,
+      type: type,
+      primeFactors: _calculatePrimeFactors(value),
+      isPowerEnemy: true,
+      powerBase: base,
+      powerExponent: exponent,
+    );
+  }
 
-enum EnemySize {
-  small,
-  medium,
-  large,
+  /// Create a normal enemy
+  factory Enemy.normal({
+    required int value,
+    required EnemyType type,
+  }) {
+    return Enemy(
+      currentValue: value,
+      originalValue: value,
+      type: type,
+      primeFactors: _calculatePrimeFactors(value),
+      isPowerEnemy: false,
+    );
+  }
+
+  /// Calculate power (base^exponent)
+  static int _power(int base, int exponent) {
+    int result = 1;
+    for (int i = 0; i < exponent; i++) {
+      result *= base;
+    }
+    return result;
+  }
+
+  /// Calculate prime factors of a number
+  static List<int> _calculatePrimeFactors(int n) {
+    final factors = <int>[];
+    int temp = n;
+
+    // Check for factor 2
+    while (temp % 2 == 0) {
+      factors.add(2);
+      temp ~/= 2;
+    }
+
+    // Check for odd factors
+    for (int i = 3; i * i <= temp; i += 2) {
+      while (temp % i == 0) {
+        factors.add(i);
+        temp ~/= i;
+      }
+    }
+
+    // If temp is a prime greater than 2
+    if (temp > 2) {
+      factors.add(temp);
+    }
+
+    return factors;
+  }
 }

--- a/lib/domain/entities/enemy.freezed.dart
+++ b/lib/domain/entities/enemy.freezed.dart
@@ -203,6 +203,11 @@ class _$EnemyImpl extends _Enemy {
   final int? powerExponent;
 
   @override
+  String toString() {
+    return 'Enemy(currentValue: $currentValue, originalValue: $originalValue, type: $type, primeFactors: $primeFactors, isPowerEnemy: $isPowerEnemy, powerBase: $powerBase, powerExponent: $powerExponent)';
+  }
+
+  @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&

--- a/lib/domain/entities/inventory.freezed.dart
+++ b/lib/domain/entities/inventory.freezed.dart
@@ -16,7 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$Inventory {
-  List<Prime> get primes => throw _privateConstructorUsedError;
+  List<Item> get primes => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $InventoryCopyWith<Inventory> get copyWith =>
@@ -28,7 +28,7 @@ abstract class $InventoryCopyWith<$Res> {
   factory $InventoryCopyWith(Inventory value, $Res Function(Inventory) then) =
       _$InventoryCopyWithImpl<$Res, Inventory>;
   @useResult
-  $Res call({List<Prime> primes});
+  $Res call({List<Item> primes});
 }
 
 /// @nodoc
@@ -50,7 +50,7 @@ class _$InventoryCopyWithImpl<$Res, $Val extends Inventory>
       primes: null == primes
           ? _value.primes
           : primes // ignore: cast_nullable_to_non_nullable
-              as List<Prime>,
+              as List<Item>,
     ) as $Val);
   }
 }
@@ -63,7 +63,7 @@ abstract class _$$InventoryImplCopyWith<$Res>
       __$$InventoryImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({List<Prime> primes});
+  $Res call({List<Item> primes});
 }
 
 /// @nodoc
@@ -83,7 +83,7 @@ class __$$InventoryImplCopyWithImpl<$Res>
       primes: null == primes
           ? _value._primes
           : primes // ignore: cast_nullable_to_non_nullable
-              as List<Prime>,
+              as List<Item>,
     ));
   }
 }
@@ -91,14 +91,14 @@ class __$$InventoryImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$InventoryImpl extends _Inventory {
-  const _$InventoryImpl({final List<Prime> primes = const []})
+  const _$InventoryImpl({final List<Item> primes = const []})
       : _primes = primes,
         super._();
 
-  final List<Prime> _primes;
+  final List<Item> _primes;
   @override
   @JsonKey()
-  List<Prime> get primes {
+  List<Item> get primes {
     if (_primes is EqualUnmodifiableListView) return _primes;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_primes);
@@ -124,11 +124,11 @@ class _$InventoryImpl extends _Inventory {
 }
 
 abstract class _Inventory extends Inventory {
-  const factory _Inventory({final List<Prime> primes}) = _$InventoryImpl;
+  const factory _Inventory({final List<Item> primes}) = _$InventoryImpl;
   const _Inventory._() : super._();
 
   @override
-  List<Prime> get primes;
+  List<Item> get primes;
   @override
   @JsonKey(ignore: true)
   _$$InventoryImplCopyWith<_$InventoryImpl> get copyWith =>
@@ -141,7 +141,7 @@ mixin _$InventoryStats {
   int get uniquePrimes => throw _privateConstructorUsedError;
   int get smallPrimes => throw _privateConstructorUsedError;
   int get largePrimes => throw _privateConstructorUsedError;
-  Prime? get mostUsedPrime => throw _privateConstructorUsedError;
+  Item? get mostUsedPrime => throw _privateConstructorUsedError;
   double get averageUsage => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -160,10 +160,10 @@ abstract class $InventoryStatsCopyWith<$Res> {
       int uniquePrimes,
       int smallPrimes,
       int largePrimes,
-      Prime? mostUsedPrime,
+      Item? mostUsedPrime,
       double averageUsage});
 
-  $PrimeCopyWith<$Res>? get mostUsedPrime;
+  $ItemCopyWith<$Res>? get mostUsedPrime;
 }
 
 /// @nodoc
@@ -206,7 +206,7 @@ class _$InventoryStatsCopyWithImpl<$Res, $Val extends InventoryStats>
       mostUsedPrime: freezed == mostUsedPrime
           ? _value.mostUsedPrime
           : mostUsedPrime // ignore: cast_nullable_to_non_nullable
-              as Prime?,
+              as Item?,
       averageUsage: null == averageUsage
           ? _value.averageUsage
           : averageUsage // ignore: cast_nullable_to_non_nullable
@@ -216,12 +216,12 @@ class _$InventoryStatsCopyWithImpl<$Res, $Val extends InventoryStats>
 
   @override
   @pragma('vm:prefer-inline')
-  $PrimeCopyWith<$Res>? get mostUsedPrime {
+  $ItemCopyWith<$Res>? get mostUsedPrime {
     if (_value.mostUsedPrime == null) {
       return null;
     }
 
-    return $PrimeCopyWith<$Res>(_value.mostUsedPrime!, (value) {
+    return $ItemCopyWith<$Res>(_value.mostUsedPrime!, (value) {
       return _then(_value.copyWith(mostUsedPrime: value) as $Val);
     });
   }
@@ -240,11 +240,11 @@ abstract class _$$InventoryStatsImplCopyWith<$Res>
       int uniquePrimes,
       int smallPrimes,
       int largePrimes,
-      Prime? mostUsedPrime,
+      Item? mostUsedPrime,
       double averageUsage});
 
   @override
-  $PrimeCopyWith<$Res>? get mostUsedPrime;
+  $ItemCopyWith<$Res>? get mostUsedPrime;
 }
 
 /// @nodoc
@@ -285,7 +285,7 @@ class __$$InventoryStatsImplCopyWithImpl<$Res>
       mostUsedPrime: freezed == mostUsedPrime
           ? _value.mostUsedPrime
           : mostUsedPrime // ignore: cast_nullable_to_non_nullable
-              as Prime?,
+              as Item?,
       averageUsage: null == averageUsage
           ? _value.averageUsage
           : averageUsage // ignore: cast_nullable_to_non_nullable
@@ -314,7 +314,7 @@ class _$InventoryStatsImpl implements _InventoryStats {
   @override
   final int largePrimes;
   @override
-  final Prime? mostUsedPrime;
+  final Item? mostUsedPrime;
   @override
   final double averageUsage;
 
@@ -360,7 +360,7 @@ abstract class _InventoryStats implements InventoryStats {
       required final int uniquePrimes,
       required final int smallPrimes,
       required final int largePrimes,
-      final Prime? mostUsedPrime,
+      final Item? mostUsedPrime,
       required final double averageUsage}) = _$InventoryStatsImpl;
 
   @override
@@ -372,7 +372,7 @@ abstract class _InventoryStats implements InventoryStats {
   @override
   int get largePrimes;
   @override
-  Prime? get mostUsedPrime;
+  Item? get mostUsedPrime;
   @override
   double get averageUsage;
   @override

--- a/lib/domain/entities/prime.dart
+++ b/lib/domain/entities/prime.dart
@@ -4,26 +4,32 @@ import '../../core/utils/math_utils.dart';
 part 'prime.freezed.dart';
 
 @freezed
-class Prime with _$Prime {
-  const factory Prime({
+class Item with _$Item {
+  const factory Item({
     required int value,
     required int count,
     required DateTime firstObtained,
     @Default(0) int usageCount,
-  }) = _Prime;
+  }) = _Item;
 
-  const Prime._();
+  const Item._();
 
   /// Check if the value is actually prime
   bool get isPrime => MathUtils.isPrime(value);
 
+  /// Check if this item is available for use
+  bool get isAvailable => count > 0;
+
+  /// Check if this item is empty
+  bool get isEmpty => count == 0;
+
   /// Create a copy with updated count
-  Prime increaseCount([int amount = 1]) {
+  Item increaseCount([int amount = 1]) {
     return copyWith(count: count + amount);
   }
 
   /// Create a copy with decreased count
-  Prime decreaseCount([int amount = 1]) {
+  Item decreaseCount([int amount = 1]) {
     if (count < amount) {
       throw StateError('Cannot decrease count below zero');
     }
@@ -31,12 +37,20 @@ class Prime with _$Prime {
   }
 
   /// Create a copy with increased usage count
-  Prime increaseUsage([int amount = 1]) {
+  Item increaseUsage([int amount = 1]) {
     return copyWith(usageCount: usageCount + amount);
   }
 
-  /// Check if this prime is available for use
-  bool get isAvailable => count > 0;
+  /// Consume items and return new item
+  Item consume(int amount) {
+    final newCount = (count - amount).clamp(0, double.infinity).toInt();
+    return copyWith(count: newCount);
+  }
+
+  /// Add items and return new item
+  Item add(int amount) {
+    return copyWith(count: count + amount);
+  }
 
   /// Check if this is a small prime (for inventory limits)
   bool get isSmallPrime => value <= 10;
@@ -44,12 +58,15 @@ class Prime with _$Prime {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is Prime && other.value == value;
+    return other is Item && other.value == value;
   }
 
   @override
   int get hashCode => value.hashCode;
 
   @override
-  String toString() => 'Prime($value x$count)';
+  String toString() => 'Item($value x$count)';
 }
+
+/// 後方互換性のためのエイリアス
+typedef Prime = Item;

--- a/lib/domain/entities/prime.freezed.dart
+++ b/lib/domain/entities/prime.freezed.dart
@@ -15,28 +15,28 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
-mixin _$Prime {
+mixin _$Item {
   int get value => throw _privateConstructorUsedError;
   int get count => throw _privateConstructorUsedError;
   DateTime get firstObtained => throw _privateConstructorUsedError;
   int get usageCount => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
-  $PrimeCopyWith<Prime> get copyWith => throw _privateConstructorUsedError;
+  $ItemCopyWith<Item> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $PrimeCopyWith<$Res> {
-  factory $PrimeCopyWith(Prime value, $Res Function(Prime) then) =
-      _$PrimeCopyWithImpl<$Res, Prime>;
+abstract class $ItemCopyWith<$Res> {
+  factory $ItemCopyWith(Item value, $Res Function(Item) then) =
+      _$ItemCopyWithImpl<$Res, Item>;
   @useResult
   $Res call({int value, int count, DateTime firstObtained, int usageCount});
 }
 
 /// @nodoc
-class _$PrimeCopyWithImpl<$Res, $Val extends Prime>
-    implements $PrimeCopyWith<$Res> {
-  _$PrimeCopyWithImpl(this._value, this._then);
+class _$ItemCopyWithImpl<$Res, $Val extends Item>
+    implements $ItemCopyWith<$Res> {
+  _$ItemCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -73,21 +73,20 @@ class _$PrimeCopyWithImpl<$Res, $Val extends Prime>
 }
 
 /// @nodoc
-abstract class _$$PrimeImplCopyWith<$Res> implements $PrimeCopyWith<$Res> {
-  factory _$$PrimeImplCopyWith(
-          _$PrimeImpl value, $Res Function(_$PrimeImpl) then) =
-      __$$PrimeImplCopyWithImpl<$Res>;
+abstract class _$$ItemImplCopyWith<$Res> implements $ItemCopyWith<$Res> {
+  factory _$$ItemImplCopyWith(
+          _$ItemImpl value, $Res Function(_$ItemImpl) then) =
+      __$$ItemImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int value, int count, DateTime firstObtained, int usageCount});
 }
 
 /// @nodoc
-class __$$PrimeImplCopyWithImpl<$Res>
-    extends _$PrimeCopyWithImpl<$Res, _$PrimeImpl>
-    implements _$$PrimeImplCopyWith<$Res> {
-  __$$PrimeImplCopyWithImpl(
-      _$PrimeImpl _value, $Res Function(_$PrimeImpl) _then)
+class __$$ItemImplCopyWithImpl<$Res>
+    extends _$ItemCopyWithImpl<$Res, _$ItemImpl>
+    implements _$$ItemImplCopyWith<$Res> {
+  __$$ItemImplCopyWithImpl(_$ItemImpl _value, $Res Function(_$ItemImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +97,7 @@ class __$$PrimeImplCopyWithImpl<$Res>
     Object? firstObtained = null,
     Object? usageCount = null,
   }) {
-    return _then(_$PrimeImpl(
+    return _then(_$ItemImpl(
       value: null == value
           ? _value.value
           : value // ignore: cast_nullable_to_non_nullable
@@ -121,8 +120,8 @@ class __$$PrimeImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PrimeImpl extends _Prime {
-  const _$PrimeImpl(
+class _$ItemImpl extends _Item {
+  const _$ItemImpl(
       {required this.value,
       required this.count,
       required this.firstObtained,
@@ -142,17 +141,17 @@ class _$PrimeImpl extends _Prime {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PrimeImplCopyWith<_$PrimeImpl> get copyWith =>
-      __$$PrimeImplCopyWithImpl<_$PrimeImpl>(this, _$identity);
+  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
+      __$$ItemImplCopyWithImpl<_$ItemImpl>(this, _$identity);
 }
 
-abstract class _Prime extends Prime {
-  const factory _Prime(
+abstract class _Item extends Item {
+  const factory _Item(
       {required final int value,
       required final int count,
       required final DateTime firstObtained,
-      final int usageCount}) = _$PrimeImpl;
-  const _Prime._() : super._();
+      final int usageCount}) = _$ItemImpl;
+  const _Item._() : super._();
 
   @override
   int get value;
@@ -164,6 +163,6 @@ abstract class _Prime extends Prime {
   int get usageCount;
   @override
   @JsonKey(ignore: true)
-  _$$PrimeImplCopyWith<_$PrimeImpl> get copyWith =>
+  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/domain/entities/stage.dart
+++ b/lib/domain/entities/stage.dart
@@ -63,6 +63,7 @@ class StageClearResult with _$StageClearResult {
     required List<int> defeatedEnemies,
     required bool isPerfect,
     required bool isNewRecord,
+    @Default([]) List<int> rewardItems, // 獲得した報酬アイテム
   }) = _StageClearResult;
 }
 

--- a/lib/domain/entities/stage.freezed.dart
+++ b/lib/domain/entities/stage.freezed.dart
@@ -613,6 +613,7 @@ mixin _$StageClearResult {
   List<int> get defeatedEnemies => throw _privateConstructorUsedError;
   bool get isPerfect => throw _privateConstructorUsedError;
   bool get isNewRecord => throw _privateConstructorUsedError;
+  List<int> get rewardItems => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $StageClearResultCopyWith<StageClearResult> get copyWith =>
@@ -636,7 +637,8 @@ abstract class $StageClearResultCopyWith<$Res> {
       Duration totalTime,
       List<int> defeatedEnemies,
       bool isPerfect,
-      bool isNewRecord});
+      bool isNewRecord,
+      List<int> rewardItems});
 }
 
 /// @nodoc
@@ -663,6 +665,7 @@ class _$StageClearResultCopyWithImpl<$Res, $Val extends StageClearResult>
     Object? defeatedEnemies = null,
     Object? isPerfect = null,
     Object? isNewRecord = null,
+    Object? rewardItems = null,
   }) {
     return _then(_value.copyWith(
       stageNumber: null == stageNumber
@@ -709,6 +712,10 @@ class _$StageClearResultCopyWithImpl<$Res, $Val extends StageClearResult>
           ? _value.isNewRecord
           : isNewRecord // ignore: cast_nullable_to_non_nullable
               as bool,
+      rewardItems: null == rewardItems
+          ? _value.rewardItems
+          : rewardItems // ignore: cast_nullable_to_non_nullable
+              as List<int>,
     ) as $Val);
   }
 }
@@ -732,7 +739,8 @@ abstract class _$$StageClearResultImplCopyWith<$Res>
       Duration totalTime,
       List<int> defeatedEnemies,
       bool isPerfect,
-      bool isNewRecord});
+      bool isNewRecord,
+      List<int> rewardItems});
 }
 
 /// @nodoc
@@ -757,6 +765,7 @@ class __$$StageClearResultImplCopyWithImpl<$Res>
     Object? defeatedEnemies = null,
     Object? isPerfect = null,
     Object? isNewRecord = null,
+    Object? rewardItems = null,
   }) {
     return _then(_$StageClearResultImpl(
       stageNumber: null == stageNumber
@@ -803,6 +812,10 @@ class __$$StageClearResultImplCopyWithImpl<$Res>
           ? _value.isNewRecord
           : isNewRecord // ignore: cast_nullable_to_non_nullable
               as bool,
+      rewardItems: null == rewardItems
+          ? _value._rewardItems
+          : rewardItems // ignore: cast_nullable_to_non_nullable
+              as List<int>,
     ));
   }
 }
@@ -821,8 +834,10 @@ class _$StageClearResultImpl implements _StageClearResult {
       required this.totalTime,
       required final List<int> defeatedEnemies,
       required this.isPerfect,
-      required this.isNewRecord})
-      : _defeatedEnemies = defeatedEnemies;
+      required this.isNewRecord,
+      final List<int> rewardItems = const []})
+      : _defeatedEnemies = defeatedEnemies,
+        _rewardItems = rewardItems;
 
   @override
   final int stageNumber;
@@ -852,10 +867,18 @@ class _$StageClearResultImpl implements _StageClearResult {
   final bool isPerfect;
   @override
   final bool isNewRecord;
+  final List<int> _rewardItems;
+  @override
+  @JsonKey()
+  List<int> get rewardItems {
+    if (_rewardItems is EqualUnmodifiableListView) return _rewardItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rewardItems);
+  }
 
   @override
   String toString() {
-    return 'StageClearResult(stageNumber: $stageNumber, isCleared: $isCleared, stars: $stars, score: $score, victories: $victories, escapes: $escapes, wrongClaims: $wrongClaims, totalTime: $totalTime, defeatedEnemies: $defeatedEnemies, isPerfect: $isPerfect, isNewRecord: $isNewRecord)';
+    return 'StageClearResult(stageNumber: $stageNumber, isCleared: $isCleared, stars: $stars, score: $score, victories: $victories, escapes: $escapes, wrongClaims: $wrongClaims, totalTime: $totalTime, defeatedEnemies: $defeatedEnemies, isPerfect: $isPerfect, isNewRecord: $isNewRecord, rewardItems: $rewardItems)';
   }
 
   @override
@@ -881,7 +904,9 @@ class _$StageClearResultImpl implements _StageClearResult {
             (identical(other.isPerfect, isPerfect) ||
                 other.isPerfect == isPerfect) &&
             (identical(other.isNewRecord, isNewRecord) ||
-                other.isNewRecord == isNewRecord));
+                other.isNewRecord == isNewRecord) &&
+            const DeepCollectionEquality()
+                .equals(other._rewardItems, _rewardItems));
   }
 
   @override
@@ -897,7 +922,8 @@ class _$StageClearResultImpl implements _StageClearResult {
       totalTime,
       const DeepCollectionEquality().hash(_defeatedEnemies),
       isPerfect,
-      isNewRecord);
+      isNewRecord,
+      const DeepCollectionEquality().hash(_rewardItems));
 
   @JsonKey(ignore: true)
   @override
@@ -919,7 +945,8 @@ abstract class _StageClearResult implements StageClearResult {
       required final Duration totalTime,
       required final List<int> defeatedEnemies,
       required final bool isPerfect,
-      required final bool isNewRecord}) = _$StageClearResultImpl;
+      required final bool isNewRecord,
+      final List<int> rewardItems}) = _$StageClearResultImpl;
 
   @override
   int get stageNumber;
@@ -943,6 +970,8 @@ abstract class _StageClearResult implements StageClearResult {
   bool get isPerfect;
   @override
   bool get isNewRecord;
+  @override
+  List<int> get rewardItems;
   @override
   @JsonKey(ignore: true)
   _$$StageClearResultImplCopyWith<_$StageClearResultImpl> get copyWith =>

--- a/lib/domain/entities/temp_reward.dart
+++ b/lib/domain/entities/temp_reward.dart
@@ -1,0 +1,54 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'prime.dart';
+
+part 'temp_reward.freezed.dart';
+
+@freezed
+class TempReward with _$TempReward {
+  const factory TempReward({
+    required List<Item> tempItems,
+    required DateTime battleStartTime,
+    @Default(false) bool isFinalized,
+  }) = _TempReward;
+
+  const TempReward._();
+
+  /// Add a temporary item
+  TempReward addTempItem(Item item) {
+    final existingIndex =
+        tempItems.indexWhere((tempItem) => tempItem.value == item.value);
+
+    if (existingIndex >= 0) {
+      // Update existing item
+      final updatedItems = tempItems.map((tempItem) {
+        if (tempItem.value == item.value) {
+          return tempItem.add(item.count);
+        }
+        return tempItem;
+      }).toList();
+      return copyWith(tempItems: updatedItems);
+    } else {
+      // Add new item
+      return copyWith(tempItems: [...tempItems, item]);
+    }
+  }
+
+  /// Finalize the temporary rewards
+  TempReward finalize() {
+    return copyWith(isFinalized: true);
+  }
+
+  /// Discard the temporary rewards
+  TempReward discard() {
+    return copyWith(
+      tempItems: [],
+      isFinalized: false,
+    );
+  }
+
+  /// Get total count of temporary items
+  int get totalTempItems => tempItems.fold(0, (sum, item) => sum + item.count);
+
+  /// Check if there are temporary rewards
+  bool get hasTempRewards => tempItems.isNotEmpty;
+}

--- a/lib/domain/entities/temp_reward.freezed.dart
+++ b/lib/domain/entities/temp_reward.freezed.dart
@@ -1,0 +1,187 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'temp_reward.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$TempReward {
+  List<Item> get tempItems => throw _privateConstructorUsedError;
+  DateTime get battleStartTime => throw _privateConstructorUsedError;
+  bool get isFinalized => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $TempRewardCopyWith<TempReward> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TempRewardCopyWith<$Res> {
+  factory $TempRewardCopyWith(
+          TempReward value, $Res Function(TempReward) then) =
+      _$TempRewardCopyWithImpl<$Res, TempReward>;
+  @useResult
+  $Res call({List<Item> tempItems, DateTime battleStartTime, bool isFinalized});
+}
+
+/// @nodoc
+class _$TempRewardCopyWithImpl<$Res, $Val extends TempReward>
+    implements $TempRewardCopyWith<$Res> {
+  _$TempRewardCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? tempItems = null,
+    Object? battleStartTime = null,
+    Object? isFinalized = null,
+  }) {
+    return _then(_value.copyWith(
+      tempItems: null == tempItems
+          ? _value.tempItems
+          : tempItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      battleStartTime: null == battleStartTime
+          ? _value.battleStartTime
+          : battleStartTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      isFinalized: null == isFinalized
+          ? _value.isFinalized
+          : isFinalized // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TempRewardImplCopyWith<$Res>
+    implements $TempRewardCopyWith<$Res> {
+  factory _$$TempRewardImplCopyWith(
+          _$TempRewardImpl value, $Res Function(_$TempRewardImpl) then) =
+      __$$TempRewardImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<Item> tempItems, DateTime battleStartTime, bool isFinalized});
+}
+
+/// @nodoc
+class __$$TempRewardImplCopyWithImpl<$Res>
+    extends _$TempRewardCopyWithImpl<$Res, _$TempRewardImpl>
+    implements _$$TempRewardImplCopyWith<$Res> {
+  __$$TempRewardImplCopyWithImpl(
+      _$TempRewardImpl _value, $Res Function(_$TempRewardImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? tempItems = null,
+    Object? battleStartTime = null,
+    Object? isFinalized = null,
+  }) {
+    return _then(_$TempRewardImpl(
+      tempItems: null == tempItems
+          ? _value._tempItems
+          : tempItems // ignore: cast_nullable_to_non_nullable
+              as List<Item>,
+      battleStartTime: null == battleStartTime
+          ? _value.battleStartTime
+          : battleStartTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      isFinalized: null == isFinalized
+          ? _value.isFinalized
+          : isFinalized // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$TempRewardImpl extends _TempReward {
+  const _$TempRewardImpl(
+      {required final List<Item> tempItems,
+      required this.battleStartTime,
+      this.isFinalized = false})
+      : _tempItems = tempItems,
+        super._();
+
+  final List<Item> _tempItems;
+  @override
+  List<Item> get tempItems {
+    if (_tempItems is EqualUnmodifiableListView) return _tempItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tempItems);
+  }
+
+  @override
+  final DateTime battleStartTime;
+  @override
+  @JsonKey()
+  final bool isFinalized;
+
+  @override
+  String toString() {
+    return 'TempReward(tempItems: $tempItems, battleStartTime: $battleStartTime, isFinalized: $isFinalized)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TempRewardImpl &&
+            const DeepCollectionEquality()
+                .equals(other._tempItems, _tempItems) &&
+            (identical(other.battleStartTime, battleStartTime) ||
+                other.battleStartTime == battleStartTime) &&
+            (identical(other.isFinalized, isFinalized) ||
+                other.isFinalized == isFinalized));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_tempItems),
+      battleStartTime,
+      isFinalized);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TempRewardImplCopyWith<_$TempRewardImpl> get copyWith =>
+      __$$TempRewardImplCopyWithImpl<_$TempRewardImpl>(this, _$identity);
+}
+
+abstract class _TempReward extends TempReward {
+  const factory _TempReward(
+      {required final List<Item> tempItems,
+      required final DateTime battleStartTime,
+      final bool isFinalized}) = _$TempRewardImpl;
+  const _TempReward._() : super._();
+
+  @override
+  List<Item> get tempItems;
+  @override
+  DateTime get battleStartTime;
+  @override
+  bool get isFinalized;
+  @override
+  @JsonKey(ignore: true)
+  _$$TempRewardImplCopyWith<_$TempRewardImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentation/providers/battle_session_provider.dart
+++ b/lib/presentation/providers/battle_session_provider.dart
@@ -15,6 +15,7 @@ class BattleSessionState {
   final List<int> defeatedEnemies;
   final List<int> usedPrimesInCurrentBattle; // 現在のバトルで使用した素数
   final List<Prime>? stageStartInventory; // ステージ開始時のアイテム状態
+  final List<Prime>? originalMainInventory; // ステージ挑戦前のメインインベントリ
 
   const BattleSessionState({
     this.stageNumber,
@@ -26,6 +27,7 @@ class BattleSessionState {
     this.defeatedEnemies = const [],
     this.usedPrimesInCurrentBattle = const [],
     this.stageStartInventory,
+    this.originalMainInventory,
   });
 
   BattleSessionState copyWith({
@@ -38,6 +40,7 @@ class BattleSessionState {
     List<int>? defeatedEnemies,
     List<int>? usedPrimesInCurrentBattle,
     List<Prime>? stageStartInventory,
+    List<Prime>? originalMainInventory,
   }) {
     return BattleSessionState(
       stageNumber: stageNumber ?? this.stageNumber,
@@ -50,6 +53,7 @@ class BattleSessionState {
       usedPrimesInCurrentBattle:
           usedPrimesInCurrentBattle ?? this.usedPrimesInCurrentBattle,
       stageStartInventory: stageStartInventory ?? this.stageStartInventory,
+      originalMainInventory: originalMainInventory ?? this.originalMainInventory,
     );
   }
 
@@ -70,17 +74,19 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
       isPracticeMode: false,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(currentInventory), // アイテム状態をコピーして保存
+      originalMainInventory: List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
     );
   }
 
   /// 選択されたアイテムでステージバトルを開始
   void startStageWithSelectedItems(
-      int stageNumber, List<Prime> selectedInventory) {
+      int stageNumber, List<Prime> selectedInventory, List<Prime> originalMainInventory) {
     state = BattleSessionState(
       stageNumber: stageNumber,
       isPracticeMode: false,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(selectedInventory), // 選択されたアイテム状態をコピーして保存
+      originalMainInventory: List.from(originalMainInventory), // ステージ挑戦前のメインインベントリを保存
     );
 
     Logger.logBattle('Started stage', data: {
@@ -99,6 +105,7 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
       isPracticeMode: true,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(currentInventory), // アイテム状態をコピーして保存
+      originalMainInventory: List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
     );
   }
 
@@ -107,7 +114,7 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
     state = state.copyWith(
       victories: state.victories + 1,
       defeatedEnemies: [...state.defeatedEnemies, defeatedEnemy],
-      usedPrimesInCurrentBattle: [], // 勝利時にリセット
+      // usedPrimesInCurrentBattleはリセットしない - ステージ終了時にのみリセット
     );
   }
 
@@ -129,7 +136,7 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
   void recordEscape() {
     state = state.copyWith(
       escapes: state.escapes + 1,
-      usedPrimesInCurrentBattle: [], // 逃走時にリセット
+      // usedPrimesInCurrentBattleはリセットしない - ステージ終了時にのみリセット
     );
   }
 

--- a/lib/presentation/providers/battle_session_provider.dart
+++ b/lib/presentation/providers/battle_session_provider.dart
@@ -41,6 +41,7 @@ class BattleSessionState {
     List<int>? usedPrimesInCurrentBattle,
     List<Prime>? stageStartInventory,
     List<Prime>? originalMainInventory,
+    bool clearOriginalMainInventory = false,
   }) {
     return BattleSessionState(
       stageNumber: stageNumber ?? this.stageNumber,
@@ -53,8 +54,9 @@ class BattleSessionState {
       usedPrimesInCurrentBattle:
           usedPrimesInCurrentBattle ?? this.usedPrimesInCurrentBattle,
       stageStartInventory: stageStartInventory ?? this.stageStartInventory,
-      originalMainInventory:
-          originalMainInventory ?? this.originalMainInventory,
+      originalMainInventory: clearOriginalMainInventory
+          ? null
+          : (originalMainInventory ?? this.originalMainInventory),
     );
   }
 
@@ -155,6 +157,13 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
   void resetSession() {
     state = BattleSessionState(
       sessionStartTime: DateTime.now(),
+    );
+  }
+
+  /// originalMainInventoryをクリアして復元処理を防ぐ
+  void clearOriginalInventory() {
+    state = state.copyWith(
+      clearOriginalMainInventory: true,
     );
   }
 

--- a/lib/presentation/providers/battle_session_provider.dart
+++ b/lib/presentation/providers/battle_session_provider.dart
@@ -53,7 +53,8 @@ class BattleSessionState {
       usedPrimesInCurrentBattle:
           usedPrimesInCurrentBattle ?? this.usedPrimesInCurrentBattle,
       stageStartInventory: stageStartInventory ?? this.stageStartInventory,
-      originalMainInventory: originalMainInventory ?? this.originalMainInventory,
+      originalMainInventory:
+          originalMainInventory ?? this.originalMainInventory,
     );
   }
 
@@ -74,19 +75,21 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
       isPracticeMode: false,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(currentInventory), // アイテム状態をコピーして保存
-      originalMainInventory: List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
+      originalMainInventory:
+          List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
     );
   }
 
   /// 選択されたアイテムでステージバトルを開始
-  void startStageWithSelectedItems(
-      int stageNumber, List<Prime> selectedInventory, List<Prime> originalMainInventory) {
+  void startStageWithSelectedItems(int stageNumber,
+      List<Prime> selectedInventory, List<Prime> originalMainInventory) {
     state = BattleSessionState(
       stageNumber: stageNumber,
       isPracticeMode: false,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(selectedInventory), // 選択されたアイテム状態をコピーして保存
-      originalMainInventory: List.from(originalMainInventory), // ステージ挑戦前のメインインベントリを保存
+      originalMainInventory:
+          List.from(originalMainInventory), // ステージ挑戦前のメインインベントリを保存
     );
 
     Logger.logBattle('Started stage', data: {
@@ -105,7 +108,8 @@ class BattleSessionNotifier extends StateNotifier<BattleSessionState> {
       isPracticeMode: true,
       sessionStartTime: DateTime.now(),
       stageStartInventory: List.from(currentInventory), // アイテム状態をコピーして保存
-      originalMainInventory: List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
+      originalMainInventory:
+          List.from(currentInventory), // ステージ挑戦前のメインインベントリを保存
     );
   }
 

--- a/lib/presentation/screens/battle/battle_screen.dart
+++ b/lib/presentation/screens/battle/battle_screen.dart
@@ -1158,7 +1158,6 @@ class _PrimeButton extends ConsumerWidget {
                   ),
                 ],
               ),
-
             ],
           ),
         ),

--- a/lib/presentation/screens/battle/battle_screen.dart
+++ b/lib/presentation/screens/battle/battle_screen.dart
@@ -1365,7 +1365,12 @@ class _ActionButtonsSection extends ConsumerWidget {
         // 3. 使用したアイテムの記録をリセット
         ref.read(battleSessionProvider.notifier).resetUsedPrimes();
 
-        // 4. 報酬データを含む新しいStageClearResultを作成
+        // 4. originalMainInventoryをクリアして、後続の復元処理を防ぐ
+        ref.read(battleSessionProvider.notifier).clearOriginalInventory();
+        Logger.logBattle(
+            'Cleared originalMainInventory to prevent restoration after stage clear');
+
+        // 5. 報酬データを含む新しいStageClearResultを作成
         final clearResultWithRewards =
             clearResult.copyWith(rewardItems: rewardItems);
 

--- a/lib/presentation/screens/battle/battle_screen.dart
+++ b/lib/presentation/screens/battle/battle_screen.dart
@@ -1095,8 +1095,6 @@ class _PrimeButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isAvailable = prime.count > 0;
-    final recentlyAcquired = ref.watch(recentlyAcquiredPrimesProvider);
-    final isRecentlyAcquired = recentlyAcquired.containsKey(prime.value);
 
     return Material(
       color: isAvailable
@@ -1161,37 +1159,6 @@ class _PrimeButton extends ConsumerWidget {
                 ],
               ),
 
-              // Recently acquired indicator
-              if (isRecentlyAcquired)
-                Positioned(
-                  top: 4,
-                  right: 4,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 4,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColors.victoryGreen,
-                      borderRadius: BorderRadius.circular(8),
-                      boxShadow: [
-                        BoxShadow(
-                          color: AppColors.victoryGreen.withOpacity(0.5),
-                          blurRadius: 4,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: const Text(
-                      '+1',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 10,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
             ],
           ),
         ),

--- a/lib/presentation/screens/battle/battle_screen.dart
+++ b/lib/presentation/screens/battle/battle_screen.dart
@@ -126,7 +126,7 @@ class _BattleScreenState extends ConsumerState<BattleScreen> {
 
     // Reset used primes at stage end (game over)
     ref.read(battleSessionProvider.notifier).resetUsedPrimes();
-    
+
     // Clear temporary rewards (game over)
     ref.read(battleTempRewardsProvider.notifier).clearTempRewards();
 
@@ -1303,41 +1303,46 @@ class _ActionButtonsSection extends ConsumerWidget {
         if (!session.isPracticeMode) {
           // デバッグ: クリア前のメインインベントリ状態
           final beforeInventory = ref.read(inventoryProvider);
-          Logger.logBattle('Before stage clear - main inventory',
-              data: {
-                'total_items': beforeInventory.length,
-                'items': beforeInventory.map((p) => '${p.value}x${p.count}').join(', ')
-              });
-          
+          Logger.logBattle('Before stage clear - main inventory', data: {
+            'total_items': beforeInventory.length,
+            'items':
+                beforeInventory.map((p) => '${p.value}x${p.count}').join(', ')
+          });
+
           // 1. メインインベントリをオリジナル状態に復元
           if (session.originalMainInventory != null) {
             ref
                 .read(inventoryProvider.notifier)
                 .restoreInventory(session.originalMainInventory!);
-            
+
             Logger.logBattle('Restored main inventory to original state',
                 data: {
                   'restored_items': session.originalMainInventory!.length,
-                  'items': session.originalMainInventory!.map((p) => '${p.value}x${p.count}').join(', ')
+                  'items': session.originalMainInventory!
+                      .map((p) => '${p.value}x${p.count}')
+                      .join(', ')
                 });
           }
-          
+
           // 2. 一時的な報酬をメインインベントリに追加
-          final tempRewards = ref.read(battleTempRewardsProvider.notifier).finalizeTempRewards();
+          final tempRewards = ref
+              .read(battleTempRewardsProvider.notifier)
+              .finalizeTempRewards();
           for (final reward in tempRewards) {
             for (int i = 0; i < reward.count; i++) {
               ref.read(inventoryProvider.notifier).addPrime(reward.value);
             }
           }
-          
+
           // デバッグ: クリア後のメインインベントリ状態
           final afterInventory = ref.read(inventoryProvider);
-          Logger.logBattle('After stage clear - main inventory',
-              data: {
-                'total_items': afterInventory.length,
-                'items': afterInventory.map((p) => '${p.value}x${p.count}').join(', '),
-                'temp_rewards': tempRewards.map((r) => '${r.value}x${r.count}').join(', ')
-              });
+          Logger.logBattle('After stage clear - main inventory', data: {
+            'total_items': afterInventory.length,
+            'items':
+                afterInventory.map((p) => '${p.value}x${p.count}').join(', '),
+            'temp_rewards':
+                tempRewards.map((r) => '${r.value}x${r.count}').join(', ')
+          });
         } else {
           // 練習モード - 一時的な報酬のみクリア
           ref.read(battleTempRewardsProvider.notifier).finalizeTempRewards();

--- a/lib/presentation/screens/common/result_screen_base.dart
+++ b/lib/presentation/screens/common/result_screen_base.dart
@@ -4,6 +4,7 @@ import '../../theme/dimensions.dart';
 import '../../routes/app_router.dart';
 import '../../providers/battle_session_provider.dart';
 import '../../providers/inventory_provider.dart';
+import '../../providers/stage_progress_provider.dart';
 
 /// 結果画面共通のボタン機能
 mixin ResultScreenMixin {
@@ -32,10 +33,10 @@ mixin ResultScreenMixin {
   void goToStageSelect(BuildContext context, WidgetRef ref) {
     // アイテム状態を復元
     final session = ref.read(battleSessionProvider);
-    if (session.stageStartInventory != null) {
+    if (session.originalMainInventory != null) {
       ref
           .read(inventoryProvider.notifier)
-          .restoreInventory(session.stageStartInventory!);
+          .restoreInventory(session.originalMainInventory!);
     }
 
     // バトルセッションをリセット
@@ -50,36 +51,32 @@ mixin ResultScreenMixin {
   void retryStage(BuildContext context, WidgetRef ref, int stageNumber) {
     // アイテム状態を復元
     final session = ref.read(battleSessionProvider);
-    if (session.stageStartInventory != null) {
+    if (session.originalMainInventory != null) {
       ref
           .read(inventoryProvider.notifier)
-          .restoreInventory(session.stageStartInventory!);
+          .restoreInventory(session.originalMainInventory!);
     }
 
     // バトルセッションをリセット
     ref.read(battleSessionProvider.notifier).resetSession();
 
-    // 現在のアイテム状態を取得
-    final currentInventory = ref.read(inventoryProvider);
+    // 指定されたステージの情報を取得
+    final stages = ref.read(stageProgressProvider);
+    final stage = stages.firstWhere((s) => s.stageNumber == stageNumber);
 
-    // 同じステージを再開
-    ref
-        .read(battleSessionProvider.notifier)
-        .startStage(stageNumber, currentInventory);
-
-    // 現在の画面を閉じてバトル画面に遷移
+    // 現在の画面を閉じてアイテム選択画面に遷移
     Navigator.pop(context);
-    AppRouter.goToBattle(context);
+    AppRouter.goToStageItemSelection(context, stage);
   }
 
   /// 練習モードを開始
   void goToPractice(BuildContext context, WidgetRef ref) {
     // アイテム状態を復元
     final session = ref.read(battleSessionProvider);
-    if (session.stageStartInventory != null) {
+    if (session.originalMainInventory != null) {
       ref
           .read(inventoryProvider.notifier)
-          .restoreInventory(session.stageStartInventory!);
+          .restoreInventory(session.originalMainInventory!);
     }
 
     // バトルセッションをリセット

--- a/lib/presentation/screens/stage/stage_clear_screen.dart
+++ b/lib/presentation/screens/stage/stage_clear_screen.dart
@@ -9,6 +9,7 @@ import '../../providers/stage_progress_provider.dart';
 import '../common/result_screen_base.dart';
 import '../../../flutter_gen/gen_l10n/app_localizations.dart';
 import '../game_over/game_over_screen.dart'; // For LocalizedResultScreenButtons
+import '../../../core/utils/logger.dart';
 
 class StageClearScreen extends ConsumerStatefulWidget {
   final StageClearResult clearResult;
@@ -237,6 +238,12 @@ class _StageClearScreenState extends ConsumerState<StageClearScreen>
 
               const SizedBox(height: Dimensions.spacingL),
 
+              // 報酬表示
+              if (widget.clearResult.rewardItems.isNotEmpty)
+                _buildRewardsSection(l10n),
+
+              const SizedBox(height: Dimensions.spacingL),
+
               // ボタン
               LocalizedResultScreenButtons(
                 stageNumber: widget.clearResult.stageNumber,
@@ -408,6 +415,127 @@ class _StageClearScreenState extends ConsumerState<StageClearScreen>
               ),
             ),
           ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRewardsSection(AppLocalizations l10n) {
+    // デバッグ: 受け取った報酬データをログ出力
+    Logger.logBattle('Stage clear screen - displaying rewards', data: {
+      'total_reward_items': widget.clearResult.rewardItems.length,
+      'reward_items': widget.clearResult.rewardItems.join(', ')
+    });
+
+    // 報酬アイテムを集計（同じ値をまとめる）
+    final rewardMap = <int, int>{};
+    for (final item in widget.clearResult.rewardItems) {
+      rewardMap[item] = (rewardMap[item] ?? 0) + 1;
+    }
+
+    // 値でソート
+    final sortedRewards = rewardMap.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(Dimensions.paddingM),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            AppColors.primary.withOpacity(0.1),
+            AppColors.primaryContainer.withOpacity(0.3),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(Dimensions.radiusM),
+        border: Border.all(color: AppColors.primary.withOpacity(0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 報酬タイトル
+          Row(
+            children: [
+              const Icon(
+                Icons.card_giftcard,
+                color: AppColors.primary,
+                size: 24,
+              ),
+              const SizedBox(width: Dimensions.spacingS),
+              Text(
+                'Stage Rewards', // TODO: Localize
+                style: AppTextStyles.titleMedium.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: Dimensions.spacingM),
+
+          // 報酬アイテム一覧
+          Wrap(
+            spacing: Dimensions.spacingS,
+            runSpacing: Dimensions.spacingS,
+            children: sortedRewards.map((entry) {
+              final value = entry.key;
+              final count = entry.value;
+
+              return Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: Dimensions.paddingM,
+                  vertical: Dimensions.paddingS,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.surface,
+                  borderRadius: BorderRadius.circular(Dimensions.radiusS),
+                  border: Border.all(color: AppColors.primary.withOpacity(0.5)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: AppColors.primary.withOpacity(0.1),
+                      blurRadius: 4,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      value.toString(),
+                      style: AppTextStyles.titleSmall.copyWith(
+                        color: AppColors.primary,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    if (count > 1) ...[
+                      const SizedBox(width: Dimensions.spacingXs),
+                      Text(
+                        'x$count',
+                        style: AppTextStyles.bodySmall.copyWith(
+                          color: AppColors.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+
+          const SizedBox(height: Dimensions.spacingS),
+
+          // 合計数
+          Text(
+            'Total: ${widget.clearResult.rewardItems.length} items', // TODO: Localize
+            style: AppTextStyles.bodySmall.copyWith(
+              color: AppColors.onSurfaceVariant,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/presentation/screens/stage/stage_item_selection_screen.dart
+++ b/lib/presentation/screens/stage/stage_item_selection_screen.dart
@@ -391,10 +391,14 @@ class _StageItemSelectionScreenState
     // 選択されたアイテムで一時的なインベントリを作成
     final selectedInventory = _createSelectedInventory();
 
+    // 現在のメインインベントリを取得
+    final originalMainInventory = ref.read(inventoryProvider);
+
     // バトルセッションを開始（選択されたアイテムのみ）
     ref.read(battleSessionProvider.notifier).startStageWithSelectedItems(
           widget.stage.stageNumber,
           selectedInventory,
+          originalMainInventory,
         );
 
     // バトル画面に遷移

--- a/test/unit/item_calculation_test.dart
+++ b/test/unit/item_calculation_test.dart
@@ -45,42 +45,6 @@ void main() {
       expect(actualInventory[5], expectedPostBattleInventory[5]);
     });
 
-    test('enemy becomes 1 should give no reward', () {
-      // バトル前の状態
-      Map<int, int> preBattleInventory = {
-        2: 3,
-        3: 1,
-      };
-
-      // バトルシナリオ: 敵6を1にする
-      // 6 ÷ 2 = 3, 3 ÷ 3 = 1
-      List<int> usedPrimes = [2, 3];
-      int finalValue = 1; // 敵が1になった
-
-      // 期待される結果: 使用分だけ減って、報酬なし
-      Map<int, int> expectedPostBattleInventory = {
-        2: 2, // 3 - 1 = 2
-        3: 0, // 1 - 1 = 0
-      };
-
-      // 計算ロジックをシミュレート
-      Map<int, int> actualInventory = Map.from(preBattleInventory);
-
-      // 使用した素数を減算
-      for (int usedPrime in usedPrimes) {
-        actualInventory[usedPrime] = (actualInventory[usedPrime] ?? 0) - 1;
-      }
-
-      // 最終値が1の場合は報酬なし
-      if (finalValue > 1 && _isPrime(finalValue)) {
-        actualInventory[finalValue] = (actualInventory[finalValue] ?? 0) + 1;
-      }
-
-      // 検証
-      expect(actualInventory[2], expectedPostBattleInventory[2]);
-      expect(actualInventory[3], expectedPostBattleInventory[3]);
-    });
-
     test('multiple battles should accumulate correctly', () {
       // 初期状態
       Map<int, int> inventory = {
@@ -166,17 +130,4 @@ void main() {
       expect(postBattleTotal, preBattleTotal - 1); // 1個減少（コスト）
     });
   });
-}
-
-/// 素数判定関数（テスト用）
-bool _isPrime(int n) {
-  if (n <= 1) return false;
-  if (n <= 3) return true;
-  if (n % 2 == 0 || n % 3 == 0) return false;
-
-  for (int i = 5; i * i <= n; i += 6) {
-    if (n % i == 0 || n % (i + 2) == 0) return false;
-  }
-
-  return true;
 }


### PR DESCRIPTION
mainブランチとの主な差分

  1. 設定・環境ファイル

  - Claude設定の追加権限 (gradlew, flutter test)
  - Android SDK更新 (API 33, Gradle 8.4, Kotlin 1.9.10)

  2. 戦闘報酬システムの重大な実装不整合

  📋 現在の実装状況

  - battle_screen.dart: 最終素数のみを報酬として追加（元の仕様）
  - docs/architecture.md: 全素因数を報酬とする新仕様に更新済み

  ⚠️ 重大な問題点

  1. 実装とドキュメントの不一致
  // 実装（battle_screen.dart:1262）
  ref.read(battleTempRewardsProvider.notifier).addTempReward(enemy); // 最終素数のみ

  // ドキュメント仕様
  final allRewardPrimes = [enemy, ...usedPrimes]; // 全素因数
  2. 報酬システムの混乱
    - コード: 従来の最終素数のみ報酬
    - ドキュメント: 新しい全素因数報酬システム
    - システム間の一貫性が欠如
  3. アーキテクチャの大幅変更
    - Prime → Item への概念変更
    - BattleLoadout 新規追加
    - TempReward システム追加
    - これらの変更が実装に反映されていない

  3. 具体的な懸念点

  即座に対応が必要な問題

  1. データ不整合リスク: 新旧システムが混在
  2. テスト失敗の可能性: アーキテクチャ変更によるテスト不整合
  3. 機能破綻: 未実装の新システムへの依存

  長期的な問題

  1. 保守性の悪化: ドキュメントとコードの乖離
  2. 開発効率の低下: 仕様の不明確さ
  3. バグの温床: 設計意図と実装の差異

  4. 推奨される対応方針

  緊急対応

  1. 実装とドキュメントの整合性確認
  2. 新仕様の実装完了または元仕様への回帰決定
  3. テストケースの更新

  根本対策

  1. 変更管理プロセスの確立
  2. 実装前の設計レビュー義務化
  3. CI/CDでの整合性チェック追加
